### PR TITLE
[enhancement] have eqtools operate on numpy 2+, python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+on:
+  pull_request:
+    branches: [ "master" ]
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [
+          { name: arm Ubuntu-24.04, label: ubuntu-24.04-arm },
+          { name: x86 Ubuntu-latest, label: ubuntu-latest },
+          { name: x86 Windows-latest, label: windows-latest },          
+        ]
+
+    name: CI-${{ matrix.os.name }}
+    runs-on: ${{ matrix.os.label }}
+    steps:
+      - name: Checkout EqTools
+        uses: actions/checkout@v4
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install EqTools
+        run: python -m pip install .
+      - name: Run tests
+        run: python tests/test.py
+      - name: Run unittests
+        # Windows cannot properly load the python2 test data pickle file
+        if: runner.os != 'Windows'
+        run: python tests/unittests.py || true

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ The following packages are required or recommended:
 
 - NumPy: Required.
 - SciPy: Required.
-- F2PY: Optional, needed to build the optional `trispline` module.
+- setuptools: Required.
 - matplotlib: Optional, needed to produce plot of flux surfaces.
 - MDSplus: Optional, needed to use data stored in MDSplus trees.
 - dd: Optional, needed to use data from ASDEX-Upgrade shotfiles.
 
 All of these should be available via pip (and should be installed automatically if you run `pip install eqtools` as described in the next section). If you wish to build in place, you may first need to run:
     
-    pip install numpy scipy f2py matplotlib
+    pip install numpy scipy setuptools matplotlib
 
 Installation
 ------------

--- a/eqtools/AUGData.py
+++ b/eqtools/AUGData.py
@@ -20,7 +20,7 @@
 working with ASDEX Upgrade experimental data.
 """
 
-import scipy
+import numpy
 from collections import namedtuple
 
 from .core import PropertyAccessMixin, ModuleWarning, Equilibrium, inPolygon
@@ -436,8 +436,8 @@ class AUGDDData(Equilibrium):
         if self._fluxVol is None:
             try:
                 fluxVolNode = self._MDSTree('Vol')  # Lpf is unreliable so I have to do this trick....
-                temp = scipy.where(
-                    scipy.sum(fluxVolNode.data, axis=0)[::2] != 0
+                temp = numpy.where(
+                    numpy.sum(fluxVolNode.data, axis=0)[::2] != 0
                 )[0].max() + 1  # Find the where the volume is non-zero, give the maximum index and add one (for the core value)
 
                 self._fluxVol = fluxVolNode.data[:self._timeidxend][
@@ -510,17 +510,17 @@ class AUGDDData(Equilibrium):
             try:
                 rgeo = self.getSSQ('Rgeo')
                 RLCFSNode = self.getSSQ('rays')
-                RLCFStemp = scipy.hstack(
-                    (scipy.atleast_2d(RLCFSNode.data[:, -1]).T, RLCFSNode.data)
+                RLCFStemp = numpy.hstack(
+                    (numpy.atleast_2d(RLCFSNode.data[:, -1]).T, RLCFSNode.data)
                 )
                 templen = RLCFSNode.data.shape
 
-                self._RLCFS = scipy.tile(
+                self._RLCFS = numpy.tile(
                     rgeo.data, (templen[1] + 1, 1)
-                ).T + RLCFStemp * scipy.cos(
-                    scipy.tile(
+                ).T + RLCFStemp * numpy.cos(
+                    numpy.tile(
                         (
-                            scipy.linspace(0, 2 * scipy.pi, templen[1] + 1)
+                            numpy.linspace(0, 2 * numpy.pi, templen[1] + 1)
                         ), (templen[0], 1)
                     )
                 )  # construct a 2d grid of angles, take cos, multiply by radius
@@ -550,16 +550,16 @@ class AUGDDData(Equilibrium):
             try:
                 zgeo = self.getSSQ('Zgeo')
                 ZLCFSNode = self.getSSQ('rays')
-                ZLCFStemp = scipy.hstack(
-                    (scipy.atleast_2d(ZLCFSNode.data[:, -1]).T, ZLCFSNode.data)
+                ZLCFStemp = numpy.hstack(
+                    (numpy.atleast_2d(ZLCFSNode.data[:, -1]).T, ZLCFSNode.data)
                 )
                 templen = ZLCFSNode.data.shape
 
-                self._ZLCFS = scipy.tile(
+                self._ZLCFS = numpy.tile(
                     zgeo.data, (templen[1] + 1, 1)
-                ).T + ZLCFStemp * scipy.sin(
-                    scipy.tile(
-                        (scipy.linspace(0, 2 * scipy.pi, templen[1] + 1)),
+                ).T + ZLCFStemp * numpy.sin(
+                    numpy.tile(
+                        (numpy.linspace(0, 2 * numpy.pi, templen[1] + 1)),
                         (templen[0], 1)
                     )
                 )  # construct a 2d grid of angles, take sin, multiply by radius
@@ -624,14 +624,14 @@ class AUGDDData(Equilibrium):
                 v = path.vertices
                 RLCFS_frame.extend(v[:, 0])
                 ZLCFS_frame.extend(v[:, 1])
-                RLCFS_frame.append(scipy.nan)
-                ZLCFS_frame.append(scipy.nan)
-            RLCFS_frame = scipy.array(RLCFS_frame)
-            ZLCFS_frame = scipy.array(ZLCFS_frame)
+                RLCFS_frame.append(numpy.nan)
+                ZLCFS_frame.append(numpy.nan)
+            RLCFS_frame = numpy.array(RLCFS_frame)
+            ZLCFS_frame = numpy.array(ZLCFS_frame)
 
             # generate masking array to vessel
             if mask:
-                maskarr = scipy.array([False for i in range(len(RLCFS_frame))])
+                maskarr = numpy.array([False for i in range(len(RLCFS_frame))])
                 for i, x in enumerate(RLCFS_frame):
                     y = ZLCFS_frame[i]
                     maskarr[i] = inPolygon(Rlim, Zlim, x, y)
@@ -644,8 +644,8 @@ class AUGDDData(Equilibrium):
             RLCFS_stores.append(RLCFS_frame)
             ZLCFS_stores.append(ZLCFS_frame)
 
-        RLCFS = scipy.zeros((nt, maxlen))
-        ZLCFS = scipy.zeros((nt, maxlen))
+        RLCFS = numpy.zeros((nt, maxlen))
+        ZLCFS = numpy.zeros((nt, maxlen))
         for i in range(nt):
             RLCFS_frame = RLCFS_stores[i]
             ZLCFS_frame = ZLCFS_stores[i]
@@ -1097,9 +1097,9 @@ class AUGDDData(Equilibrium):
                 btaxvNode = self._MDSTree('Bave')
                 # technically Bave is the average over the volume, but for the core its a singular value
                 self._btaxv = btaxvNode.data[
-                    :self._timeidxend, scipy.sum(btaxvNode.data, 0) != 0
+                    :self._timeidxend, numpy.sum(btaxvNode.data, 0) != 0
                 ][:, -1]
-                self._btaxv *= scipy.sign(self.getBCentr())
+                self._btaxv *= numpy.sign(self.getBCentr())
                 self._defaultUnits['_btaxv'] = str(btaxvNode.unit)
             except (PyddError, AttributeError):
                 raise ValueError('data retrieval failed.')
@@ -1141,7 +1141,7 @@ class AUGDDData(Equilibrium):
         if self._IpCalc is None:
             try:
                 IpCalcNode = self._MDSTree('IpiPSI')
-                self._IpCalc = scipy.squeeze(IpCalcNode.data)[
+                self._IpCalc = numpy.squeeze(IpCalcNode.data)[
                     :self._timeidxend
                 ]
                 self._defaultUnits['_IpCalc'] = str(IpCalcNode.unit)
@@ -1425,7 +1425,7 @@ class AUGDDData(Equilibrium):
             currentSign (Integer): 1 for positive-direction current, -1 for negative.
         """
         if self._currentSign is None:
-            self._currentSign = -1 if scipy.mean(self.getIpMeas()) > 1e5 else 1
+            self._currentSign = -1 if numpy.mean(self.getIpMeas()) > 1e5 else 1
         return self._currentSign
 
     def getParam(self, path):
@@ -1460,13 +1460,13 @@ class AUGDDData(Equilibrium):
                 # create a dict mapping the various quantities to positions in the in the data array
                 self._SSQname = SSQnameNode.data
                 try:
-                    self._SSQname = scipy.char.strip(
+                    self._SSQname = numpy.char.strip(
                         SSQnameNode.data.view(
                             'S' + str(SSQnameNode.data.shape[1])
                         )
                     )  # concatenate and strip blanks
                 except ValueError:
-                    self._SSQname = scipy.char.strip(
+                    self._SSQname = numpy.char.strip(
                         SSQnameNode.data.T.view(
                             'S' + str(SSQnameNode.data.shape[0])
                         )
@@ -1474,7 +1474,7 @@ class AUGDDData(Equilibrium):
 
                 self._SSQname = self._SSQname[self._SSQname != '']  # remove empty entries
                 self._SSQname = dict(
-                    zip(self._SSQname, scipy.arange(self._SSQname.shape[0]))
+                    zip(self._SSQname, numpy.arange(self._SSQname.shape[0]))
                 )  # zip the dict together
 
                 self._SSQ = self._MDSTree('SSQ').data
@@ -1536,7 +1536,7 @@ class AUGDDData(Equilibrium):
                 `Z` or be a scalar. Default is True (evaluate ALL `R`, `Z` at
                 EACH element in `t`).
             make_grid (Boolean): Set to True to pass `R` and `Z` through
-                :py:func:`scipy.meshgrid` before evaluating. If this is set to
+                :py:func:`numpy.meshgrid` before evaluating. If this is set to
                 True, `R` and `Z` must each only have a single dimension, but
                 can have different lengths. Default is False (do not form
                 meshgrid).
@@ -1569,7 +1569,7 @@ class AUGDDData(Equilibrium):
 
             * **BR** (`Array or scalar float`) - The major radial component of
               the magnetic field. If all of the input arguments are scalar, then
-              a scalar is returned. Otherwise, a scipy Array is returned. If `R`
+              a scalar is returned. Otherwise, a numpy Array is returned. If `R`
               and `Z` both have the same shape then `BR` has this shape as well,
               unless the `make_grid` keyword was True, in which case `BR` has
               shape (len(`Z`), len(`R`)).
@@ -1609,7 +1609,7 @@ class AUGDDData(Equilibrium):
         return super(AUGDDData, self).rz2BR(
             R, Z, t, return_t=return_t, make_grid=make_grid, each_t=each_t,
             length_unit=length_unit
-        ) / (2 * scipy.pi)
+        ) / (2 * numpy.pi)
 
     def rz2BZ(
         self, R, Z, t, return_t=False, make_grid=False, each_t=True,
@@ -1650,7 +1650,7 @@ class AUGDDData(Equilibrium):
                 `Z` or be a scalar. Default is True (evaluate ALL `R`, `Z` at
                 EACH element in `t`).
             make_grid (Boolean): Set to True to pass `R` and `Z` through
-                :py:func:`scipy.meshgrid` before evaluating. If this is set to
+                :py:func:`numpy.meshgrid` before evaluating. If this is set to
                 True, `R` and `Z` must each only have a single dimension, but
                 can have different lengths. Default is False (do not form
                 meshgrid).
@@ -1683,7 +1683,7 @@ class AUGDDData(Equilibrium):
 
             * **BZ** (`Array or scalar float`) - The vertical component of the
               magnetic field. If all of the input arguments are scalar, then a
-              scalar is returned. Otherwise, a scipy Array is returned. If `R`
+              scalar is returned. Otherwise, a numpy Array is returned. If `R`
               and `Z` both have the same shape then `BZ` has this shape as well,
               unless the `make_grid` keyword was True, in which case `BZ` has
               shape (len(`Z`), len(`R`)).
@@ -1720,7 +1720,7 @@ class AUGDDData(Equilibrium):
 
                 BZ_mat = Eq_instance.rz2BZ(R, Z, 0.2, make_grid=True)
         """
-        return super(AUGDDData, self).rz2BZ(R, Z, t, return_t=return_t, make_grid=make_grid, each_t=each_t, length_unit=length_unit)/(2*scipy.pi)
+        return super(AUGDDData, self).rz2BZ(R, Z, t, return_t=return_t, make_grid=make_grid, each_t=each_t, length_unit=length_unit)/(2*numpy.pi)
 
 
 class YGCAUGInterface(object):
@@ -1812,13 +1812,13 @@ class YGCAUGInterface(object):
             }
 
     # ONLY CERTAIN YGC FILES EXIST I MEAN CMON ITS NOT THAT MUCH MEMORY
-    _ygc_shotfiles = scipy.array([0, 948, 8650, 9401, 12751, 14051, 14601, 16315, 18204, 19551, 21485, 25891, 30136])
+    _ygc_shotfiles = numpy.array([0, 948, 8650, 9401, 12751, 14051, 14601, 16315, 18204, 19551, 21485, 25891, 30136])
 
     def _getData(self, shot):
         try:
 
             self._ygc_shot = self._ygc_shotfiles[
-                scipy.searchsorted(self._ygc_shotfiles, [shot], 'right') - 1
+                numpy.searchsorted(self._ygc_shotfiles, [shot], 'right') - 1
             ][0]  # find nearest shotfile which is the before it
 
             if self._ygc_shot < 8650:
@@ -1900,8 +1900,8 @@ class YGCAUGInterface(object):
                 x.append(None)
                 y.append(None)
 
-        x = scipy.array(x[:-1])
-        y = scipy.array(y[:-1])
+        x = numpy.array(x[:-1])
+        y = numpy.array(y[:-1])
         return (x, y)
 
 

--- a/eqtools/CModEFIT.py
+++ b/eqtools/CModEFIT.py
@@ -20,7 +20,7 @@
 working with C-Mod EFIT data.
 """
 
-import scipy
+import numpy as np
 
 from .EFIT import EFITTree
 from .core import PropertyAccessMixin, ModuleWarning
@@ -367,8 +367,8 @@ class CModEFITTree(EFITTree):
                 x.append(None)
                 y.append(None)
 
-        x = scipy.array(x)
-        y = scipy.array(y)
+        x = np.array(x)
+        y = np.array(y)
         return (x, y)
 
     def getRCentr(self, length_unit=1):

--- a/eqtools/EFIT.py
+++ b/eqtools/EFIT.py
@@ -20,6 +20,7 @@
 with EFIT data.
 """
 
+import numpy
 import scipy
 from collections import namedtuple
 
@@ -601,12 +602,12 @@ class EFITTree(Equilibrium):
                 ZLCFS_frame.extend(v[:, 1])
                 RLCFS_frame.append(scipy.nan)
                 ZLCFS_frame.append(scipy.nan)
-            RLCFS_frame = scipy.array(RLCFS_frame)
-            ZLCFS_frame = scipy.array(ZLCFS_frame)
+            RLCFS_frame = numpy.array(RLCFS_frame)
+            ZLCFS_frame = numpy.array(ZLCFS_frame)
 
             # generate masking array to vessel
             if mask:
-                maskarr = scipy.array([False for i in range(len(RLCFS_frame))])
+                maskarr = numpy.array([False for i in range(len(RLCFS_frame))])
                 for i, x in enumerate(RLCFS_frame):
                     y = ZLCFS_frame[i]
                     maskarr[i] = inPolygon(Rlim, Zlim, x, y)

--- a/eqtools/FromArrays.py
+++ b/eqtools/FromArrays.py
@@ -18,7 +18,7 @@
 
 from .core import Equilibrium
 
-import scipy
+import numpy
 
 
 class ArrayEquilibrium(Equilibrium):
@@ -91,17 +91,17 @@ class ArrayEquilibrium(Equilibrium):
     """
     def __init__(self, psiRZ, rGrid, zGrid, time, q, fluxVol, psiLCFS, psiAxis,
                  rmag, zmag, Rout, **kwargs):
-        self._psiRZ = scipy.asarray(psiRZ, dtype=float)
-        self._rGrid = scipy.asarray(rGrid, dtype=float)
-        self._zGrid = scipy.asarray(zGrid, dtype=float)
-        self._time = scipy.asarray(time, dtype=float)
-        self._qpsi = scipy.asarray(q, dtype=float)
-        self._fluxVol = scipy.asarray(fluxVol, dtype=float)
-        self._psiLCFS = scipy.asarray(psiLCFS, dtype=float)
-        self._psiAxis = scipy.asarray(psiAxis, dtype=float)
-        self._rmag = scipy.asarray(rmag, dtype=float)
-        self._zmag = scipy.asarray(zmag, dtype=float)
-        self._RmidLCFS = scipy.asarray(Rout, dtype=float)
+        self._psiRZ = numpy.asarray(psiRZ, dtype=float)
+        self._rGrid = numpy.asarray(rGrid, dtype=float)
+        self._zGrid = numpy.asarray(zGrid, dtype=float)
+        self._time = numpy.asarray(time, dtype=float)
+        self._qpsi = numpy.asarray(q, dtype=float)
+        self._fluxVol = numpy.asarray(fluxVol, dtype=float)
+        self._psiLCFS = numpy.asarray(psiLCFS, dtype=float)
+        self._psiAxis = numpy.asarray(psiAxis, dtype=float)
+        self._rmag = numpy.asarray(rmag, dtype=float)
+        self._zmag = numpy.asarray(zmag, dtype=float)
+        self._RmidLCFS = numpy.asarray(Rout, dtype=float)
 
         self._defaultUnits = {}
         self._defaultUnits['_psiRZ'] = 'Wb/rad'

--- a/eqtools/NSTXEFIT.py
+++ b/eqtools/NSTXEFIT.py
@@ -20,7 +20,7 @@
 working with NSTX EFIT data.
 """
 
-import scipy
+import numpy
 
 from .EFIT import EFITTree
 from .core import PropertyAccessMixin, ModuleWarning
@@ -215,7 +215,7 @@ class NSTXEFITTree(EFITTree):
                 self._defaultUnits['_RmidPsi'], length_unit
             )
         else:
-            unit_factor = scipy.array([1.])
+            unit_factor = numpy.array([1.])
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=RuntimeWarning)

--- a/eqtools/_tricub.c
+++ b/eqtools/_tricub.c
@@ -1,6 +1,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include "_tricub.h"
 
 /*****************************************************************
  
@@ -156,17 +157,18 @@ int A_v2[64][64] = {
 
 double factorial[4] = {1.0,1.0,2.0,6.0}; /* value needed for derivatives, and a lookup table is the easiest/fastest method */
 
-int clip(int x, int a)
+inline int clip(int x, int a)
 { /* use of a set of ternary operators to bound a value x between 0 and a */
   return x > a - 1 ? a - 1 : (x < 0 ? 0 : x);
 }
 
 
-int ismonotonic(double val[], int ix)
+long ismonotonic(double val[], int ix)
 {   /* while loop based check of monotonicity,
        so on very large bases that fail, it 
        stops early. Starts at end.  */
-  int counter = ix - 1,output = 1;
+  int counter = ix - 1;
+  long output = 1;
   
   while( counter )
     { counter--;  
@@ -180,11 +182,12 @@ int ismonotonic(double val[], int ix)
 }
 
 
-int isregular(double val[], int ix)
+long isregular(double val[], int ix)
 {   /* while loop based check of monotonicity,
        so on very large bases that fail, it 
        stops early. Starts at end.  */
-  int counter = ix - 2,output = 1;
+  int counter = ix - 2;
+  long output = 1;
   double eps = 1e-6; /* Difference between values within .001%  */
   double temp = val[counter] - val[counter + 1];
   while( counter )
@@ -199,7 +202,7 @@ int isregular(double val[], int ix)
 }
 
 
-int ijk2n(int i, int j, int k)
+inline int ijk2n(int i, int j, int k)
 {
   return(i+4*j+16*k);
 }
@@ -534,7 +537,6 @@ void nonreg_ev(double val[], double x0[], double x1[], double x2[], double f[], 
   free(tempx2);
   free(pos);
   free(indx);
-
 }
 
 
@@ -599,9 +601,7 @@ void nonreg_ev_full(double val[], double x0[], double x1[], double x2[], double 
   free(tempx2);
   free(pos);
   free(indx);
-
 }
-
 
 
 void reg_ev(double val[], double x0[], double x1[], double x2[], double f[], double fx0[], double fx1[], double fx2[], int ix0, int ix1, int ix2, int ix)
@@ -742,7 +742,6 @@ void reg_ev_full(double val[], double x0[], double x1[], double x2[], double f[]
   free(tempx1);
   free(tempx2);
 }
-
 
 
 void ev(double val[], double x0[], double x1[], double x2[], double f[], double fx0[], double fx1[], double fx2[], int ix0, int ix1, int ix2, int ix)

--- a/eqtools/_tricub.h
+++ b/eqtools/_tricub.h
@@ -1,0 +1,29 @@
+/*****************************************************************
+ 
+    This file is part of the eqtools package.
+
+    EqTools is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    EqTools is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with EqTools.  If not, see <http://www.gnu.org/licenses/>.
+
+    Copyright 2025 Ian C. Faust
+
+******************************************************************/
+
+long ismonotonic(double val[], int ix);
+long isregular(double val[], int ix);
+
+void nonreg_ev(double val[], double x0[], double x1[], double x2[], double f[], double fx0[], double fx1[], double fx2[], int ix0, int ix1, int ix2, int ix);
+void nonreg_ev_full(double val[], double x0[], double x1[], double x2[], double f[], double fx0[], double fx1[], double fx2[], int ix0, int ix1, int ix2, int ix, int d0, int d1, int d2);
+void reg_ev(double val[], double x0[], double x1[], double x2[], double f[], double fx0[], double fx1[], double fx2[], int ix0, int ix1, int ix2, int ix);
+void reg_ev_full(double val[], double x0[], double x1[], double x2[], double f[], double fx0[], double fx1[], double fx2[], int ix0, int ix1, int ix2, int ix, int d0, int d1, int d2);
+void ev(double val[], double x0[], double x1[], double x2[], double f[], double fx0[], double fx1[], double fx2[], int ix0, int ix1, int ix2, int ix);

--- a/eqtools/_tricubmodule.c
+++ b/eqtools/_tricubmodule.c
@@ -1,0 +1,320 @@
+#include <Python.h>
+
+#include <numpy/arrayobject.h>
+#include <numpy/numpyconfig.h>
+
+#include "_tricub.h"
+
+/*****************************************************************
+
+    This file is part of the eqtools package.
+
+    EqTools is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    EqTools is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with EqTools.  If not, see <http://www.gnu.org/licenses/>.
+
+    Copyright 2025 Ian C. Faust
+
+******************************************************************/
+
+#define LENGTH_ASSERT(a, i)                                                    \
+  if (check_1d_array(a, i))                                                    \
+  return 1
+
+#define ARRAY_SHAPE(a, i) PyArray_DIM((PyArrayObject *)a, i)
+#define ARRAY_DATA(a) PyArray_DATA((PyArrayObject *)a)
+
+#define CHECK_ARRAY(a)                                                         \
+  if (to_array(&a))                                                            \
+  return 1
+
+struct input {
+  double *x0;
+  double *x1;
+  double *x2;
+  double *f;
+  double *fx0;
+  double *fx1;
+  double *fx2;
+  int ix0;
+  int ix1;
+  int ix2;
+  int ix;
+  int d0;
+  int d1;
+  int d2;
+};
+
+static inline int
+to_array(PyObject **obj) { /* Check in numpy array, dtype is double, and if the
+                            * number of dimensions of the array is correct, then
+                            * return the numpy C-contiguous array. Otherwise,
+                            * raise a specified Python error and return NULL.
+                            */
+  PyArrayObject *array = NULL;
+
+  if (!((*obj) && PyArray_Check(*obj))) {
+    PyErr_SetString(PyExc_TypeError, "Input is not a numpy.ndarray subtype");
+    return 1;
+  }
+  array = (PyArrayObject *)*obj;
+
+  if (PyArray_TYPE(array) != NPY_DOUBLE) {
+    PyErr_SetString(PyExc_TypeError, "array must be dtype double");
+    return 1;
+  }
+
+  if (!PyArray_ISCARRAY_RO(array))
+    array = PyArray_GETCONTIGUOUS(*obj);
+    *obj = (PyObject*) array;
+
+  return 0;
+}
+
+static inline int check_1d_array(PyObject *array, int length) {
+  if (array && ARRAY_SHAPE(array, 0) != length) {
+    PyErr_SetString(PyExc_TypeError, "1-d array has incorrect length");
+    return 1;
+  }
+  return 0;
+}
+
+static int to_scalar(PyObject *obj, void *output) {
+  // if not supplied do nothing
+  if (!obj)
+    return 0;
+
+  if (PyArray_CheckScalar(obj)) {
+    PyErr_SetString(PyExc_TypeError, "Input is not a numpy scalar");
+    return 1;
+  }
+
+  if (PyArray_TYPE((PyArrayObject *)obj) != NPY_INT) {
+    PyErr_SetString(PyExc_TypeError, "scalar must be dtype int");
+    return 1;
+  }
+
+  PyArray_ScalarAsCtype(obj, output);
+  return 0;
+}
+
+static inline int parse_input(PyObject *args, struct input *data) {
+  PyObject *x0obj, *x1obj, *x2obj, *fobj, *fx0obj, *fx1obj, *fx2obj;
+  PyObject *d0obj = NULL, *d1obj = NULL, *d2obj = NULL;
+  if (!PyArg_ParseTuple(args, "OOOOOOO|OOO", &x0obj, &x1obj, &x2obj, &fobj,
+                       &fx0obj, &fx1obj, &fx2obj, &d0obj, &d1obj, &d2obj))
+    return 1;
+
+  CHECK_ARRAY(x0obj);
+  CHECK_ARRAY(x1obj);
+  CHECK_ARRAY(x2obj);
+  CHECK_ARRAY(fobj);
+  CHECK_ARRAY(fx0obj);
+  CHECK_ARRAY(fx1obj);
+  CHECK_ARRAY(fx2obj);
+
+  // get dimension for testing
+  data->ix = ARRAY_SHAPE(x0obj, 0);
+
+  LENGTH_ASSERT(x1obj, data->ix);
+  LENGTH_ASSERT(x2obj, data->ix);
+
+  // assert f is 3 dimensions
+  if (!fobj || PyArray_NDIM((PyArrayObject *)fobj) != 3) {
+    PyErr_SetString(PyExc_TypeError, "f array is not 3 dimensional");
+    return 1;
+  }
+
+  data->ix0 = ARRAY_SHAPE(fobj, 2);
+  data->ix1 = ARRAY_SHAPE(fobj, 1);
+  data->ix2 = ARRAY_SHAPE(fobj, 0);
+
+  LENGTH_ASSERT(fx0obj, data->ix0);
+  LENGTH_ASSERT(fx1obj, data->ix1);
+  LENGTH_ASSERT(fx2obj, data->ix2);
+  // set values for C code
+  data->x0 = (double *)ARRAY_DATA(x0obj);
+  data->x1 = (double *)ARRAY_DATA(x1obj);
+  data->x2 = (double *)ARRAY_DATA(x2obj);
+  data->f = (double *)ARRAY_DATA(fobj);
+  data->fx0 = (double *)ARRAY_DATA(fx0obj);
+  data->fx1 = (double *)ARRAY_DATA(fx1obj);
+  data->fx2 = (double *)ARRAY_DATA(fx2obj);
+
+  if (d0obj && to_scalar(d0obj, &data->d0))
+    return 1;
+  if (d1obj && to_scalar(d0obj, &data->d1))
+    return 1;
+  if (d2obj && to_scalar(d0obj, &data->d2))
+    return 1;
+
+  return 0;
+}
+
+static PyObject *python_reg_ev(
+    PyObject *self,
+    PyObject *args) { /* If the above function returns -1, an
+                       * appropriate Python exception will      have been
+                       * set, and the function simply returns NULL
+                       */
+  double *val;
+  struct input s;
+  npy_intp length;
+  PyObject *output;
+
+  if (parse_input(args, &s))
+    return NULL;
+  length = (npy_intp)s.ix;
+  output = PyArray_SimpleNew(1, &length, NPY_DOUBLE);
+  val = (double *)ARRAY_DATA(output);
+
+  reg_ev(val, s.x0, s.x1, s.x2, s.f, s.fx0, s.fx1, s.fx2, s.ix0, s.ix1, s.ix2,
+         s.ix);
+  return output;
+}
+
+static PyObject *python_reg_ev_full(
+    PyObject *self,
+    PyObject *args) { /* If the above function returns -1, an appropriate Python
+                       * exception will have been set, and the function simply
+                       * returns NULL
+                       */
+  double *val;
+  struct input s;
+  npy_intp length;
+  PyObject *output;
+
+  if (parse_input(args, &s))
+    return NULL;
+  length = (npy_intp)s.ix;
+  output = PyArray_SimpleNew(1, &length, NPY_DOUBLE);
+  val = (double *)ARRAY_DATA(output);
+
+  reg_ev_full(val, s.x0, s.x1, s.x2, s.f, s.fx0, s.fx1, s.fx2, s.ix0, s.ix1,
+              s.ix2, s.ix, s.d0, s.d1, s.d2);
+  return output;
+}
+
+static PyObject *python_nonreg_ev(
+    PyObject *self,
+    PyObject *args) { /* If the above function returns -1, an appropriate Python
+                       * exception will have been set, and the function simply
+                       * returns NULL
+                       */
+  double *val;
+  struct input s;
+  npy_intp length;
+  PyObject *output;
+
+  if (parse_input(args, &s))
+    return NULL;
+  length = (npy_intp)s.ix;
+  output = PyArray_SimpleNew(1, &length, NPY_DOUBLE);
+  val = (double *)ARRAY_DATA(output);
+
+  nonreg_ev(val, s.x0, s.x1, s.x2, s.f, s.fx0, s.fx1, s.fx2, s.ix0, s.ix1,
+            s.ix2, s.ix);
+  return output;
+}
+
+static PyObject *python_nonreg_ev_full(
+    PyObject *self,
+    PyObject *args) { /* If the above function returns -1, an appropriate Python
+                       * exception will have been set, and the function simply
+                       * returns NULL
+                       */
+  double *val;
+  struct input s;
+  npy_intp length;
+  PyObject *output;
+
+  if (parse_input(args, &s))
+    return NULL;
+  length = (npy_intp)s.ix;
+  output = PyArray_SimpleNew(1, &length, NPY_DOUBLE);
+  val = (double *)ARRAY_DATA(output);
+
+  nonreg_ev_full(val, s.x0, s.x1, s.x2, s.f, s.fx0, s.fx1, s.fx2, s.ix0, s.ix1,
+                 s.ix2, s.ix, s.d0, s.d1, s.d2);
+  return output;
+}
+
+static PyObject *
+python_ev(PyObject *self,
+          PyObject *args) { /* If the above function returns -1, an appropriate
+                             * Python exception will have been set, and the
+                             * function simply returns NULL
+                             */
+  double *val;
+  struct input s;
+  npy_intp length;
+  PyObject *output;
+
+  if (parse_input(args, &s))
+    return NULL;
+  length = (npy_intp)s.ix;
+  output = PyArray_SimpleNew(1, &length, NPY_DOUBLE);
+  val = (double *)ARRAY_DATA(output);
+
+  ev(val, s.x0, s.x1, s.x2, s.f, s.fx0, s.fx1, s.fx2, s.ix0, s.ix1, s.ix2,
+     s.ix);
+  return output;
+}
+
+static PyObject *python_ismonotonic(PyObject *self, PyObject *arg) {
+  int ix;
+  double *data;
+
+  if (to_array(&arg))
+    return NULL;
+  ix = ARRAY_SHAPE(arg, 0);
+  data = (double *)ARRAY_DATA(arg);
+  return PyBool_FromLong(ismonotonic(data, ix));
+}
+
+static PyObject *python_isregular(PyObject *self, PyObject *arg) {
+  int ix;
+  double *data;
+  if (to_array(&arg))
+    return NULL;
+
+  ix = ARRAY_SHAPE(arg, 0);
+  data = (double *)ARRAY_DATA(arg);
+  return PyBool_FromLong(isregular(data, ix));
+}
+
+static PyMethodDef TricubMethods[] = {
+    {"reg_ev", python_reg_ev, METH_VARARGS, ""},
+    {"reg_ev_full", python_reg_ev_full, METH_VARARGS, ""},
+    {"nonreg_ev", python_nonreg_ev, METH_VARARGS, ""},
+    {"nonreg_ev_full", python_nonreg_ev_full, METH_VARARGS, ""},
+    {"ev", python_ev, METH_VARARGS, ""},
+    {"ismonotonic", python_ismonotonic, METH_O, ""},
+    {"isregular", python_isregular, METH_O, ""},
+    {NULL, NULL, 0, NULL} /* Sentinel */
+};
+
+static struct PyModuleDef _tricubStruct = {PyModuleDef_HEAD_INIT,
+                                           "_tricub",
+                                           "",
+                                           -1,
+                                           TricubMethods,
+                                           NULL,
+                                           NULL,
+                                           NULL,
+                                           NULL};
+
+/* Module initialization */
+PyObject *PyInit__tricub(void) {
+  import_array();
+  return PyModule_Create(&_tricubStruct);
+}

--- a/eqtools/eqdskreader.py
+++ b/eqtools/eqdskreader.py
@@ -25,7 +25,7 @@ Classes:
         equilibrium data.
 """
 
-import scipy
+import numpy
 import glob
 import re
 import csv
@@ -234,7 +234,7 @@ class EqdskReader(Equilibrium):
                 time = re.findall(r'\d+', timestring)[0]
                 tunits = timestring.split(time)[1]
                 timeConvertDict = {'ms': 1./1000., 's': 1.}
-                self._time = scipy.array([float(time)*timeConvertDict[tunits]]) # returns time in seconds as array
+                self._time = numpy.array([float(time)*timeConvertDict[tunits]]) # returns time in seconds as array
 
             except KeyError:
                 tunits = None
@@ -250,14 +250,14 @@ class EqdskReader(Equilibrium):
             line = re.findall(r'-?\d\.\d*[eE][-+]\d*', line)     # regex magic!
             xdim = float(line[0])     # width of R-axis in grid
             zdim = float(line[1])     # height of Z-axis in grid
-            self._RCentr = scipy.array(float(line[2]))    # rcentr for Bcentr
+            self._RCentr = numpy.array(float(line[2]))    # rcentr for Bcentr
             self._defaultUnits['_RCentr'] = 'm'
             rgrid0 = float(line[3])   # start point of R grid
             zmid = float(line[4])     # midpoint of Z grid
 
             # construct EFIT grid
-            self._rGrid = scipy.linspace(rgrid0, rgrid0 + xdim, nw)
-            self._zGrid = scipy.linspace(zmid - zdim/2.0, zmid + zdim/2.0, nh)
+            self._rGrid = numpy.linspace(rgrid0, rgrid0 + xdim, nw)
+            self._zGrid = numpy.linspace(zmid - zdim/2.0, zmid + zdim/2.0, nh)
             # drefit = (self._rGrid[-1] - self._rGrid[0])/(nw-1)
             # dzefit = (self._zGrid[-1] - self._zGrid[0])/(nh-1)
             self._defaultUnits['_rGrid'] = 'm'
@@ -266,13 +266,13 @@ class EqdskReader(Equilibrium):
             # read R,Z of magnetic axis, psi at magnetic axis and LCFS, and bzero
             line = next(reader)[0]
             line = re.findall(r'-?\d\.\d*[eE][-+]\d*', line)
-            self._rmag = scipy.array([float(line[0])])
-            self._zmag = scipy.array([float(line[1])])
+            self._rmag = numpy.array([float(line[0])])
+            self._zmag = numpy.array([float(line[1])])
             self._defaultUnits['_rmag'] = 'm'
             self._defaultUnits['_zmag'] = 'm'
-            self._psiAxis = scipy.array([float(line[2])])
-            self._psiLCFS = scipy.array([float(line[3])])
-            self._BCentr = scipy.array([float(line[4])])
+            self._psiAxis = numpy.array([float(line[2])])
+            self._psiLCFS = numpy.array([float(line[3])])
+            self._BCentr = numpy.array([float(line[4])])
             self._defaultUnits['_psiAxis'] = 'Wb/rad'
             self._defaultUnits['_psiLCFS'] = 'Wb/rad'
 
@@ -280,7 +280,7 @@ class EqdskReader(Equilibrium):
             # dummy, R of magnetic axis (duplicate), dummy
             line = next(reader)[0]
             line = re.findall(r'-?\d\.\d*[eE][-+]\d*', line)
-            self._IpCalc = scipy.array([float(line[0])])
+            self._IpCalc = numpy.array([float(line[0])])
             self._defaultUnits['_IpCalc'] = 'A'
 
             # read Z of magnetic axis (duplicate), dummy, psi at LCFS (duplicate), dummy, dummy
@@ -298,7 +298,7 @@ class EqdskReader(Equilibrium):
                 line = re.findall(r'-?\d\.\d*[eE][-+]\d*', line)
                 for val in line:
                     self._fpol.append(float(val))
-            self._fpol = scipy.array(self._fpol).reshape((1, nw))
+            self._fpol = numpy.array(self._fpol).reshape((1, nw))
             self._defaultUnits['_fpol'] = 'T m'
 
             # and likewise for pressure
@@ -308,7 +308,7 @@ class EqdskReader(Equilibrium):
                 line = re.findall(r'-?\d\.\d*[eE][-+]\d*', line)
                 for val in line:
                     self._fluxPres.append(float(val))
-            self._fluxPres = scipy.array(self._fluxPres).reshape((1, nw))
+            self._fluxPres = numpy.array(self._fluxPres).reshape((1, nw))
             self._defaultUnits['_fluxPres'] = 'Pa'
 
             # geqdsk written as negative for positive plasma current
@@ -319,7 +319,7 @@ class EqdskReader(Equilibrium):
                 line = re.findall(r'-?\d\.\d*[eE][-+]\d*', line)
                 for val in line:
                     self._ffprim.append(float(val))
-            self._ffprim = scipy.array(self._ffprim).reshape((1, nw))
+            self._ffprim = numpy.array(self._ffprim).reshape((1, nw))
             self._defaultUnits['_ffprim'] = 'T^2 m'
 
             self._pprime = []
@@ -328,7 +328,7 @@ class EqdskReader(Equilibrium):
                 line = re.findall(r'-?\d\.\d*[eE][-+]\d*', line)
                 for val in line:
                     self._pprime.append(float(val))
-            self._pprime = scipy.array(self._pprime).reshape((1, nw))
+            self._pprime = numpy.array(self._pprime).reshape((1, nw))
             self._defaultUnits['_pprime'] = 'J/m^2'
 
             # read the 2d [nw,nh] array for psiRZ
@@ -345,7 +345,7 @@ class EqdskReader(Equilibrium):
                 line = re.findall(r'-?\d\.\d*[eE][-+]\d*', line)
                 for val in line:
                     psis.append(float(val))
-            self._psiRZ = scipy.array(psis).reshape((1, nh, nw), order='C')
+            self._psiRZ = numpy.array(psis).reshape((1, nh, nw), order='C')
             self._defaultUnits['_psiRZ'] = 'Wb/rad'
 
             # read q(psi) profile, nw points (same basis as fpol, pres, etc.)
@@ -359,7 +359,7 @@ class EqdskReader(Equilibrium):
                 line = re.findall(r'-?\d\.\d*[eE][-+]\d*', line)
                 for val in line:
                     self._qpsi.append(float(val))
-            self._qpsi = scipy.array(self._qpsi).reshape((1, nw))
+            self._qpsi = numpy.array(self._qpsi).reshape((1, nw))
 
             # read nbbbs, limitr
             line = next(reader)[0].split()
@@ -378,7 +378,7 @@ class EqdskReader(Equilibrium):
                 line = re.findall(r'-?\d\.\d*[eE][-+]\d*', line)
                 for val in line:
                     bbbs.append(float(val))
-            bbbs = scipy.array(bbbs).reshape((2, nbbbs), order='F')
+            bbbs = numpy.array(bbbs).reshape((2, nbbbs), order='F')
             self._RLCFS = bbbs[0].reshape((1, nbbbs))
             self._ZLCFS = bbbs[1].reshape((1, nbbbs))
             self._defaultUnits['_RLCFS'] = 'm'
@@ -396,7 +396,7 @@ class EqdskReader(Equilibrium):
                 line = re.findall(r'-?\d\.\d*[eE][-+]\d*', line)
                 for val in line:
                     lim.append(float(val))
-            lim = scipy.array(lim).reshape((2, limitr), order='F')
+            lim = numpy.array(lim).reshape((2, limitr), order='F')
             self._xlim = lim[0, :]
             self._ylim = lim[1, :]
 
@@ -421,17 +421,17 @@ class EqdskReader(Equilibrium):
                         line = re.findall(r'-?\d.\d*[eE][-+]\d*', line)
                         for val in line:
                             self._presw.append(float(val))
-                    self._presw = scipy.array(self._presw).reshape((nw, 1))
+                    self._presw = numpy.array(self._presw).reshape((nw, 1))
                     self._preswp = []
                     for i in range(nrows):
                         line = next(reader)[0]
                         line = re.findall(r'-?\d.\d*[eE][-+]\d*', line)
                         for val in line:
                             self._preswp.append(float(val))
-                    self._preswp = scipy.array(self._preswp).reshape((1, nw))
+                    self._preswp = numpy.array(self._preswp).reshape((1, nw))
                 else:
-                    self._presw = scipy.atleast_2d(scipy.array([0]))
-                    self._preswp = scipy.atleast_2d(scipy.array([0]))
+                    self._presw = numpy.atleast_2d(numpy.array([0]))
+                    self._preswp = numpy.atleast_2d(numpy.array([0]))
 
                 # read ion mass density if present
                 if nmass > 0:
@@ -444,9 +444,9 @@ class EqdskReader(Equilibrium):
                         line = re.findall(r'-?\d.\d*[eE][-+]\d*', line)
                         for val in line:
                             self._dmion.append(float(val))
-                    self._dmion = scipy.array(self._dmion).reshape((1, nw))
+                    self._dmion = numpy.array(self._dmion).reshape((1, nw))
                 else:
-                    self._dmion = scipy.atleast_2d(scipy.array([0]))
+                    self._dmion = numpy.atleast_2d(numpy.array([0]))
 
                 # read rhovn
                 nrows = nw/5
@@ -458,7 +458,7 @@ class EqdskReader(Equilibrium):
                     line = re.findall(r'-?\d.\d*[eE][-+]\d*', line)
                     for val in line:
                         self._rhovn.append(float(val))
-                self._rhovn = scipy.array(self._rhovn).reshape((1, nw))
+                self._rhovn = numpy.array(self._rhovn).reshape((1, nw))
 
                 # read keecur; if >0 read workk
                 line = gfile.readline.split()
@@ -470,15 +470,15 @@ class EqdskReader(Equilibrium):
                         line = re.findall(r'-?\d.\d*[eE][-+]\d*', line)
                         for val in line:
                             self._workk.append(float(val))
-                    self._workk = scipy.array(self._workk).reshape((1, nw))
+                    self._workk = numpy.array(self._workk).reshape((1, nw))
                 else:
-                    self._workk = scipy.atleast_2d(scipy.array([0]))
+                    self._workk = numpy.atleast_2d(numpy.array([0]))
             except Exception:
-                self._presw = scipy.atleast_2d(scipy.array([0]))
-                self._preswp = scipy.atleast_2d(scipy.array([0]))
-                self._rhovn = scipy.atleast_2d(scipy.array([0]))
-                self._dmion = scipy.atleast_2d(scipy.array([0]))
-                self._workk = scipy.atleast_2d(scipy.array([0]))
+                self._presw = numpy.atleast_2d(numpy.array([0]))
+                self._preswp = numpy.atleast_2d(numpy.array([0]))
+                self._rhovn = numpy.atleast_2d(numpy.array([0]))
+                self._dmion = numpy.atleast_2d(numpy.array([0]))
+                self._workk = numpy.atleast_2d(numpy.array([0]))
 
             # read through to end of file to get footer line
             try:
@@ -630,52 +630,52 @@ class EqdskReader(Equilibrium):
             afr = AFileReader(afile)
 
             # fields
-            self._btaxp = scipy.array([afr.btaxp])
-            self._btaxv = scipy.array([afr.btaxv])
-            self._bpolav = scipy.array([afr.bpolav])
+            self._btaxp = numpy.array([afr.btaxp])
+            self._btaxv = numpy.array([afr.btaxv])
+            self._bpolav = numpy.array([afr.bpolav])
 
             # currents
-            self._IpMeas = scipy.array([afr.pasmat])
+            self._IpMeas = numpy.array([afr.pasmat])
 
             # safety factor parameters
-            self._q0 = scipy.array([afr.qqmin])
-            self._q95 = scipy.array([afr.qpsib])
-            self._qLCFS = scipy.array([afr.qout])
-            self._rq1 = scipy.array([afr.aaq1])
-            self._rq2 = scipy.array([afr.aaq2])
-            self._rq3 = scipy.array([afr.aaq3])
+            self._q0 = numpy.array([afr.qqmin])
+            self._q95 = numpy.array([afr.qpsib])
+            self._qLCFS = numpy.array([afr.qout])
+            self._rq1 = numpy.array([afr.aaq1])
+            self._rq2 = numpy.array([afr.aaq2])
+            self._rq3 = numpy.array([afr.aaq3])
 
             # shaping parameters
-            self._kappa = scipy.array([afr.eout])
-            self._dupper = scipy.array([afr.doutu])
-            self._dlower = scipy.array([afr.doutl])
+            self._kappa = numpy.array([afr.eout])
+            self._dupper = numpy.array([afr.doutu])
+            self._dlower = numpy.array([afr.doutl])
 
             # dimensional geometry parameters
-            self._aLCFS = scipy.array([afr.aout])
-            self._areaLCFS = scipy.array([afr.areao])
-            self._RmidLCFS = scipy.array([afr.rmidout])
+            self._aLCFS = numpy.array([afr.aout])
+            self._areaLCFS = numpy.array([afr.areao])
+            self._RmidLCFS = numpy.array([afr.rmidout])
 
             # calc. normalized pressure values
-            self._betat = scipy.array([afr.betat])
-            self._betap = scipy.array([afr.betap])
-            self._Li = scipy.array([afr.ali])
+            self._betat = numpy.array([afr.betat])
+            self._betap = numpy.array([afr.betap])
+            self._Li = numpy.array([afr.ali])
 
             # diamagnetic measurements
-            self._diamag = scipy.array([afr.diamag])
-            self._betatd = scipy.array([afr.betatd])
-            self._betapd = scipy.array([afr.betapd])
-            self._WDiamag = scipy.array([afr.wplasmd])
-            self._tauDiamag = scipy.array([afr.taudia])
+            self._diamag = numpy.array([afr.diamag])
+            self._betatd = numpy.array([afr.betatd])
+            self._betapd = numpy.array([afr.betapd])
+            self._WDiamag = numpy.array([afr.wplasmd])
+            self._tauDiamag = numpy.array([afr.taudia])
 
             # calculated energy
-            self._WMHD = scipy.array([afr.wplasm])
-            self._tauMHD = scipy.array([afr.taumhd])
-            self._Pinj = scipy.array([afr.pbinj])
-            self._Wbdot = scipy.array([afr.wbdot])
-            self._Wpdot = scipy.array([afr.wpdot])
+            self._WMHD = numpy.array([afr.wplasm])
+            self._tauMHD = numpy.array([afr.taumhd])
+            self._Pinj = numpy.array([afr.pbinj])
+            self._Wbdot = numpy.array([afr.wbdot])
+            self._Wpdot = numpy.array([afr.wpdot])
 
             # fitting parameters
-            self._volLCFS = scipy.array([afr.vout])
+            self._volLCFS = numpy.array([afr.vout])
             self._fluxVol = None    # not written in g- or a-file; disable volnorm mapping routine
             self._RmidPsi = None    # not written in g- or a-file, not used by fitting parameters
 
@@ -915,7 +915,7 @@ class EqdskReader(Equilibrium):
 
         Returns:
             rho (Array-like or scalar float): If all of the input arguments are
-            scalar, then a scalar is returned. Otherwise, a scipy Array
+            scalar, then a scalar is returned. Otherwise, a numpy Array
             instance is returned. If R and Z both have the same shape then
             rho has this shape as well. If the make_grid keyword was True
             then rho has shape (len(Z), len(R)).
@@ -1018,7 +1018,7 @@ class EqdskReader(Equilibrium):
 
         Returns:
             R_mid (Array or scalar float): If all of the input arguments are
-            scalar, then a scalar is returned. Otherwise, a scipy Array
+            scalar, then a scalar is returned. Otherwise, a numpy Array
             instance is returned. If `R` and `Z` both have the same shape
             then `R_mid` has this shape as well. If the make_grid keyword
             was True then `R_mid` has shape (`len(Z)`, `len(R)`).
@@ -1086,7 +1086,7 @@ class EqdskReader(Equilibrium):
 
         Returns:
             R_mid (Array-like or scalar float): If all of the input arguments
-            are scalar, then a scalar is returned. Otherwise, a scipy Array
+            are scalar, then a scalar is returned. Otherwise, a numpy Array
             instance is returned.
 
         Examples:
@@ -1139,7 +1139,7 @@ class EqdskReader(Equilibrium):
 
         Returns:
             phinorm (Array-like or scalar float): If all of the input arguments
-            are scalar, then a scalar is returned. Otherwise, a scipy Array
+            are scalar, then a scalar is returned. Otherwise, a numpy Array
             instance is returned.
 
         Examples:
@@ -1182,7 +1182,7 @@ class EqdskReader(Equilibrium):
             currentSign (Int): 1 for positive current, -1 for reversed.
         """
         if self._currentSign is None:
-            self._currentSign = 1 if scipy.mean(self.getIpCalc()) > 1e5 else -1
+            self._currentSign = 1 if numpy.mean(self.getIpCalc()) > 1e5 else -1
         return self._currentSign
 
     def getFluxGrid(self):
@@ -1227,7 +1227,7 @@ class EqdskReader(Equilibrium):
             implementations with time variation.
         """
         # scale by current sign for consistency with sign of psiRZ.
-        return -1. * self.getCurrentSign() * scipy.array(self._psiAxis)
+        return -1. * self.getCurrentSign() * numpy.array(self._psiAxis)
 
     def getFluxLCFS(self):
         """Returns psi at separatrix.
@@ -1238,7 +1238,7 @@ class EqdskReader(Equilibrium):
             implementations with time variation.
         """
         # scale by current sign for consistency with sign of psiRZ.
-        return -1 * self.getCurrentSign() * scipy.array(self._psiLCFS)
+        return -1 * self.getCurrentSign() * numpy.array(self._psiLCFS)
 
     def getRLCFS(self, length_unit=1):
         """Returns array of R-values of LCFS.
@@ -1306,14 +1306,14 @@ class EqdskReader(Equilibrium):
             v = path.vertices
             RLCFS.extend(v[:, 0])
             ZLCFS.extend(v[:, 1])
-            RLCFS.append(scipy.nan)
-            ZLCFS.append(scipy.nan)
-        RLCFS = scipy.array(RLCFS)
-        ZLCFS = scipy.array(ZLCFS)
+            RLCFS.append(numpy.nan)
+            ZLCFS.append(numpy.nan)
+        RLCFS = numpy.array(RLCFS)
+        ZLCFS = numpy.array(ZLCFS)
 
         # generate masking array
         if mask:
-            maskarr = scipy.array([False for i in range(len(RLCFS))])
+            maskarr = numpy.array([False for i in range(len(RLCFS))])
             for i, x in enumerate(RLCFS):
                 y = ZLCFS[i]
                 maskarr[i] = inPolygon(Rlim, Zlim, x, y)
@@ -2242,7 +2242,7 @@ class EqdskReader(Equilibrium):
         except AttributeError:
             try:
                 attr = self.__getattribute__('_'+name)
-                if type(attr) is scipy.array:
+                if type(attr) is numpy.array:
                     return attr.copy()
                 else:
                     return attr

--- a/eqtools/trispline.py
+++ b/eqtools/trispline.py
@@ -21,8 +21,7 @@
 contains an enhanced bivariate spline which generates bounds errors.
 """
 
-
-import scipy
+import numpy
 import scipy.interpolate
 try:
     from . import _tricub
@@ -75,7 +74,7 @@ class Spline():
     """
     def __init__(
         self, x, y, z, f, boundary='natural', dx=0, dy=0, dz=0,
-        bounds_error=True, fill_value=scipy.nan
+        bounds_error=True, fill_value=numpy.nan
     ):
         #if dx != 0 or dy != 0 or dz != 0:
         #    raise NotImplementedError(
@@ -83,17 +82,17 @@ class Spline():
         #        "interpolation if you need to compute magnetic fields!"
         #    )
 
-        self._x = scipy.array(x, dtype=float)
-        self._y = scipy.array(y, dtype=float)
-        self._z = scipy.array(z, dtype=float)
+        self._x = numpy.array(x, dtype=float)
+        self._y = numpy.array(y, dtype=float)
+        self._z = numpy.array(z, dtype=float)
 
-        self._xlim = scipy.array((x.min(), x.max()))
-        self._ylim = scipy.array((y.min(), y.max()))
-        self._zlim = scipy.array((z.min(), z.max()))
+        self._xlim = numpy.array((x.min(), x.max()))
+        self._ylim = numpy.array((y.min(), y.max()))
+        self._zlim = numpy.array((z.min(), z.max()))
 
-        self._dx = scipy.array(dx, dtype=int)
-        self._dy = scipy.array(dy, dtype=int)
-        self._dz = scipy.array(dz, dtype=int)
+        self._dx = numpy.array(dx, dtype=int)
+        self._dy = numpy.array(dy, dtype=int)
+        self._dz = numpy.array(dz, dtype=int)
 
         self.bounds_error = bounds_error
         self.fill_value = fill_value
@@ -106,15 +105,15 @@ class Spline():
             _tricub.ismonotonic(self._y) and
             _tricub.ismonotonic(self._z)
         ):
-            self._x = scipy.insert(self._x, 0, 2*self._x[0]-self._x[1])
-            self._x = scipy.append(self._x, 2*self._x[-1]-self._x[-2])
-            self._y = scipy.insert(self._y, 0, 2*self._y[0]-self._y[1])
-            self._y = scipy.append(self._y, 2*self._y[-1]-self._y[-2])
-            self._z = scipy.insert(self._z, 0, 2*self._z[0]-self._z[1])
-            self._z = scipy.append(self._z, 2*self._z[-1]-self._z[-2])
+            self._x = numpy.insert(self._x, 0, 2*self._x[0]-self._x[1])
+            self._x = numpy.append(self._x, 2*self._x[-1]-self._x[-2])
+            self._y = numpy.insert(self._y, 0, 2*self._y[0]-self._y[1])
+            self._y = numpy.append(self._y, 2*self._y[-1]-self._y[-2])
+            self._z = numpy.insert(self._z, 0, 2*self._z[0]-self._z[1])
+            self._z = numpy.append(self._z, 2*self._z[-1]-self._z[-2])
 
-        self._f = scipy.zeros(scipy.array(f.shape)+(2, 2, 2))
-        self._f[1:-1, 1:-1, 1:-1] = scipy.array(f)  # place f in center, so that it is padded by unfilled values on all sides
+        self._f = numpy.zeros(numpy.array(f.shape)+(2, 2, 2))
+        self._f[1:-1, 1:-1, 1:-1] = numpy.array(f)  # place f in center, so that it is padded by unfilled values on all sides
 
         if boundary == 'clamped':
             # faces
@@ -264,13 +263,13 @@ class Spline():
                 "A value in z is above the interpolation range."
             )
 
-        out_of_bounds = scipy.logical_not(
-            scipy.logical_or(
-                scipy.logical_or(
-                    scipy.logical_or(below_bounds_x, above_bounds_x),
-                    scipy.logical_or(below_bounds_y, above_bounds_y)
+        out_of_bounds = numpy.logical_not(
+            numpy.logical_or(
+                numpy.logical_or(
+                    numpy.logical_or(below_bounds_x, above_bounds_x),
+                    numpy.logical_or(below_bounds_y, above_bounds_y)
                 ),
-                scipy.logical_or(below_bounds_z, above_bounds_z)
+                numpy.logical_or(below_bounds_z, above_bounds_z)
             )
         )
         return out_of_bounds
@@ -294,11 +293,11 @@ class Spline():
                 of the grid
 
         """
-        x = scipy.atleast_1d(xi)
-        y = scipy.atleast_1d(yi)
-        z = scipy.atleast_1d(zi)  # This will not modify x1,y1,z1.
+        x = numpy.atleast_1d(xi)
+        y = numpy.atleast_1d(yi)
+        z = numpy.atleast_1d(zi)  # This will not modify x1,y1,z1.
 
-        val = self.fill_value*scipy.ones(x.shape)
+        val = self.fill_value*numpy.ones(x.shape)
         idx = self._check_bounds(x, y, z)
 
         if dx == 0:
@@ -368,14 +367,14 @@ class RectBivariateSpline(scipy.interpolate.RectBivariateSpline):
 
     def __init__(
         self, x, y, z, bbox=[None] * 4, kx=3, ky=3, s=0, bounds_error=True,
-        fill_value=scipy.nan
+        fill_value=numpy.nan
     ):
 
         super(RectBivariateSpline, self).__init__(
             x, y, z, bbox=bbox, kx=kx, ky=ky, s=s
         )
-        self._xlim = scipy.array((x.min(), x.max()))
-        self._ylim = scipy.array((y.min(), y.max()))
+        self._xlim = numpy.array((x.min(), x.max()))
+        self._ylim = numpy.array((y.min(), y.max()))
         self.bounds_error = bounds_error
         self.fill_value = fill_value
 
@@ -415,10 +414,10 @@ class RectBivariateSpline(scipy.interpolate.RectBivariateSpline):
                 "A value in y is above the interpolation range."
             )
 
-        out_of_bounds = scipy.logical_not(
-            scipy.logical_or(
-                scipy.logical_or(below_bounds_x, above_bounds_x),
-                scipy.logical_or(below_bounds_y, above_bounds_y)
+        out_of_bounds = numpy.logical_not(
+            numpy.logical_or(
+                numpy.logical_or(below_bounds_x, above_bounds_x),
+                numpy.logical_or(below_bounds_y, above_bounds_y)
             )
         )
         return out_of_bounds
@@ -436,9 +435,9 @@ class RectBivariateSpline(scipy.interpolate.RectBivariateSpline):
         """
         idx = self._check_bounds(xi, yi)
         # print(idx)
-        zi = self.fill_value*scipy.ones(xi.shape)
+        zi = self.fill_value*numpy.ones(xi.shape)
         zi[idx] = super(RectBivariateSpline, self).ev(
-            scipy.atleast_1d(xi)[idx], scipy.atleast_1d(yi)[idx]
+            numpy.atleast_1d(xi)[idx], numpy.atleast_1d(yi)[idx]
         )
         return zi
 
@@ -451,13 +450,13 @@ class BivariateInterpolator(object):
     """
     def __init__(self, x, y, z):
         self._ct_interp = scipy.interpolate.CloughTocher2DInterpolator(
-            scipy.hstack((scipy.atleast_2d(x).T, scipy.atleast_2d(y).T)),
+            numpy.hstack((numpy.atleast_2d(x).T, numpy.atleast_2d(y).T)),
             z
         )
 
     def ev(self, xi, yi):
         return self._ct_interp(
-            scipy.hstack((scipy.atleast_2d(xi).T, scipy.atleast_2d(yi).T))
+            numpy.hstack((numpy.atleast_2d(xi).T, numpy.atleast_2d(yi).T))
         )
 
 
@@ -477,12 +476,12 @@ class UnivariateInterpolator(scipy.interpolate.InterpolatedUnivariateSpline):
         super(UnivariateInterpolator, self).__init__(*args, **kwargs)
 
     def __call__(self, x, *args, **kwargs):
-        x = scipy.asarray(x, dtype=float)
+        x = numpy.asarray(x, dtype=float)
         out = super(UnivariateInterpolator, self).__call__(x, *args, **kwargs)
         if self.min_val is not None:
             out[out < self.min_val] = self.min_val
         if self.max_val is not None:
             out[out > self.max_val] = self.max_val
         out[(x < self.get_knots().min()) | (x > self.get_knots().max())] = \
-            scipy.nan
+            numpy.nan
         return out

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
-from numpy.distutils.core import setup, Extension
+import numpy
+from setuptools import Extension, setup
 
 tricub = Extension(
-    'eqtools._tricub', ['eqtools/_tricub.pyf', 'eqtools/_tricub.c']
+    name='eqtools._tricub',
+    sources=['eqtools/_tricubmodule.c', 'eqtools/_tricub.c'],
+    include_dirs=[numpy.get_include(), './eqtools'],
 )
 
 setup(

--- a/tests/SolovievEFIT.py
+++ b/tests/SolovievEFIT.py
@@ -24,7 +24,7 @@ Classes:
     mapping routines using the Soloviev solution to the Grad-Shafranov equation.
 """
 
-import scipy
+import numpy
 from collections import namedtuple
 from eqtools.core import Equilibrium, ModuleWarning, inPolygon
 
@@ -96,23 +96,23 @@ class CircSolovievEFIT(Equilibrium):
 
         self._currentSign = -1 if Ip > 0 else 1
         # Remember: Ip is in MA.
-        self._qstar = (2.*scipy.pi * a**2 * B0) / (4.*scipy.pi*1.e-1 * R * Ip)
+        self._qstar = (2.*numpy.pi * a**2 * B0) / (4.*numpy.pi*1.e-1 * R * Ip)
 
         # flux definitions
-        self._psiLCFS = scipy.array([0.0])
+        self._psiLCFS = numpy.array([0.0])
         self._psi0 = -0.5 * self._B0 * self._a**2 / self._qstar
-        self._psi0 = scipy.array([self._psi0])
+        self._psi0 = numpy.array([self._psi0])
 
         # RZ grid
-        self._rGrid = scipy.linspace(R-1.25*a, R+1.25*a, self._npts)
+        self._rGrid = numpy.linspace(R-1.25*a, R+1.25*a, self._npts)
         self._defaultUnits['_rGrid'] = length_unit
-        self._zGrid = scipy.linspace(-1.25*a, 1.25*a, self._npts)
+        self._zGrid = numpy.linspace(-1.25*a, 1.25*a, self._npts)
         self._defaultUnits['_zGrid'] = length_unit
 
         self._psiRZ = self.rz2psi_analytic(
             self._rGrid, self._zGrid, length_unit=length_unit, make_grid=True
         )
-        self._psiRZ = scipy.reshape(self._psiRZ, (1, npts, npts))
+        self._psiRZ = numpy.reshape(self._psiRZ, (1, npts, npts))
 
     def __str__(self):
         """string formatting for CircSolovievEFIT class.
@@ -185,11 +185,11 @@ class CircSolovievEFIT(Equilibrium):
             check_space=False
         )
 
-        R = scipy.reshape(R, oshape)
-        Z = scipy.reshape(Z, oshape)
+        R = numpy.reshape(R, oshape)
+        Z = numpy.reshape(Z, oshape)
 
-        r = scipy.sqrt((R - self._R)**2 + (Z)**2)
-        theta = scipy.arctan2(Z, (R - self._R))
+        r = numpy.sqrt((R - self._R)**2 + (Z)**2)
+        theta = numpy.arctan2(Z, (R - self._R))
         return (r, theta)
 
     def rz2psi_analytic(self, R, Z, length_unit='m', make_grid=False):
@@ -224,7 +224,7 @@ class CircSolovievEFIT(Equilibrium):
 
         Returns:
             psi: Array or scalar float.  If all of the input arguments are scalar,
-                then a scalar is returned. Otherwise, a scipy Array instance is
+                then a scalar is returned. Otherwise, a numpy Array instance is
                 returned. If R and Z both have the same shape then psi has this
                 shape as well. If the make_grid keyword was True then psi has
                 shape (len(Z), len(R)).
@@ -236,7 +236,7 @@ class CircSolovievEFIT(Equilibrium):
 
         psi = (
             A / 4. * (r**2 - self._a**2) + C / 8. * (r**2 - self._a**2) * r *
-            scipy.cos(theta)
+            numpy.cos(theta)
         )
         return psi
 
@@ -337,7 +337,7 @@ class CircSolovievEFIT(Equilibrium):
 
         Returns:
             psi: Array or scalar float. If all of the input arguments are scalar,
-                then a scalar is returned. Otherwise, a scipy Array instance is
+                then a scalar is returned. Otherwise, a numpy Array instance is
                 returned. If R and Z both have the same shape then psi has this
                 shape as well. If the make_grid keyword was True then psi has
                 shape (len(Z), len(R)).
@@ -408,7 +408,7 @@ class CircSolovievEFIT(Equilibrium):
 
         Returns:
             psinorm: Array or scalar float. If all of the input arguments are
-                scalar, then a scalar is returned. Otherwise, a scipy Array
+                scalar, then a scalar is returned. Otherwise, a numpy Array
                 instance is returned. If R and Z both have the same shape then
                 psinorm has this shape as well. If the make_grid keyword was
                 True then psinorm has shape (len(Z), len(R)).
@@ -535,7 +535,7 @@ class CircSolovievEFIT(Equilibrium):
     #################
 
     def getTimeBase(self):
-        return scipy.array([0.0])
+        return numpy.array([0.0])
 
     def getCurrentSign(self):
         """Returns the sign of the current, for flux mapping.  Note - inverted from intuitive, due to Soloviev formalism.

--- a/tests/test.py
+++ b/tests/test.py
@@ -24,7 +24,7 @@ import eqtools
 import SolovievEFIT as sefit
 import matplotlib as mpl
 import matplotlib.pyplot as plt
-import scipy
+import numpy
 import warnings
 
 warnings.simplefilter("ignore")
@@ -49,10 +49,10 @@ equil.plotFlux(False)
 # gets axes for psiRZ in equil
 R = equil.getRGrid()
 Z = equil.getZGrid()
-rGrid, zGrid = scipy.meshgrid(R, Z)
+rGrid, zGrid = numpy.meshgrid(R, Z)
 
 # construct face points as meshgrid
-rFace, zFace = scipy.meshgrid((R[:-1] + R[1:]) / 2.0, (Z[:-1] + Z[1:]) / 2.0)
+rFace, zFace = numpy.meshgrid((R[:-1] + R[1:]) / 2.0, (Z[:-1] + Z[1:]) / 2.0)
 print(rFace.shape)
 
 # plot illustration

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -1,7 +1,8 @@
 import unittest
-import scipy
+import numpy
 
 import eqtools
+import os
 import warnings
 
 try:
@@ -27,8 +28,9 @@ except:
         import cPickle as pkl
     except:
         import pickle as pkl
-    with open('test_data.pkl', 'rb') as f:
-        shot, e, et = pkl.load(f, encoding='bytes')
+    dir_path = os.path.dirname(os.path.realpath(__file__))    
+    with open(os.sep.join([dir_path, 'test_data.pkl']), 'rb') as f:
+        shot, e, et = pkl.load(f, encoding='latin1')
         if not eqtools.core._has_trispline:
             et = e
 
@@ -38,16 +40,16 @@ scalar_t = e.getTimeBase()[45]
 vector_R = e.getRGrid()
 vector_Z = e.getZGrid()
 vector_t = e.getTimeBase()[10:-10]
-matrix_R, matrix_Z = scipy.meshgrid(vector_R, vector_Z)
-matrix_t = scipy.linspace(
+matrix_R, matrix_Z = numpy.meshgrid(vector_R, vector_Z)
+matrix_t = numpy.linspace(
     vector_t.min(),
     vector_t.max(),
     len(vector_R) * len(vector_Z)
 ).reshape(matrix_R.shape)
 # psinorm may be used as a stand-in for any normalized variable.
 scalar_psinorm = 0.5
-vector_psinorm = scipy.linspace(0.0, 1.0, 100)
-matrix_psinorm = scipy.linspace(
+vector_psinorm = numpy.linspace(0.0, 1.0, 100)
+matrix_psinorm = numpy.linspace(
     0, 1.0, len(vector_R) * len(vector_Z)
 ).reshape(matrix_R.shape)
 scalar_Rmid = 0.75
@@ -70,15 +72,15 @@ class rz2psiTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psi_scalar_R_scalar_Z_scalar_t_make_grid_True_each_t_True(self):
@@ -93,15 +95,15 @@ class rz2psiTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psi_scalar_R_scalar_Z_scalar_t_make_grid_True_each_t_False(self):
@@ -116,14 +118,14 @@ class rz2psiTestCase(unittest.TestCase):
         out_t = et.rz2psi(vector_R, vector_Z, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_R),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psi_vector_R_vector_Z_scalar_t_make_grid_True_each_t_True(self):
@@ -131,14 +133,14 @@ class rz2psiTestCase(unittest.TestCase):
         out_t = et.rz2psi(vector_R, vector_Z, scalar_t, make_grid=True)
 
         self.assertEqual(out.shape, (len(vector_R), len(vector_Z)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R), len(vector_Z)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psi_vector_R_vector_Z_scalar_t_make_grid_False_each_t_False(self):
@@ -146,14 +148,14 @@ class rz2psiTestCase(unittest.TestCase):
         out_t = et.rz2psi(vector_R, vector_Z, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_R),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psi_vector_R_vector_Z_scalar_t_make_grid_True_each_t_False(self):
@@ -161,14 +163,14 @@ class rz2psiTestCase(unittest.TestCase):
         out_t = et.rz2psi(vector_R, vector_Z, scalar_t, make_grid=True, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_R), len(vector_Z)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R), len(vector_Z)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # matrix R, matrix Z, scalar t:
@@ -177,14 +179,14 @@ class rz2psiTestCase(unittest.TestCase):
         out_t = et.rz2psi(matrix_R, matrix_Z, scalar_t)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psi_matrix_R_matrix_Z_scalar_t_make_grid_True_each_t_True(self):
@@ -198,14 +200,14 @@ class rz2psiTestCase(unittest.TestCase):
         out_t = et.rz2psi(matrix_R, matrix_Z, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psi_matrix_R_matrix_Z_scalar_t_make_grid_True_each_t_False(self):
@@ -220,14 +222,14 @@ class rz2psiTestCase(unittest.TestCase):
         out_t = et.rz2psi(scalar_R, scalar_Z, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psi_scalar_R_scalar_Z_vector_t_make_grid_True_each_t_True(self):
@@ -254,14 +256,14 @@ class rz2psiTestCase(unittest.TestCase):
         out_t = et.rz2psi(vector_R, vector_Z, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_R)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_R)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psi_vector_R_vector_Z_vector_t_make_grid_True_each_t_True(self):
@@ -269,14 +271,14 @@ class rz2psiTestCase(unittest.TestCase):
         out_t = et.rz2psi(vector_R, vector_Z, vector_t, make_grid=True)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_R), len(vector_Z)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_R), len(vector_Z)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psi_vector_R_vector_Z_vector_t_make_grid_False_each_t_False(self):
@@ -297,14 +299,14 @@ class rz2psiTestCase(unittest.TestCase):
         out_t = et.rz2psi(matrix_R, matrix_Z, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_R.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_R.shape)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psi_matrix_R_matrix_Z_vector_t_make_grid_True_each_t_True(self):
@@ -343,15 +345,15 @@ class rz2psiTestCase(unittest.TestCase):
         out_t = et.rz2psi(matrix_R, matrix_Z, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: Only good to 2%.
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, 0.02)
 
     def test_rz2psi_matrix_R_matrix_Z_matrix_t_make_grid_True_each_t_False(self):
@@ -372,15 +374,15 @@ class rz2psinormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psinorm_scalar_R_scalar_Z_scalar_t_make_grid_True_each_t_True(self):
@@ -395,15 +397,15 @@ class rz2psinormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psinorm_scalar_R_scalar_Z_scalar_t_make_grid_True_each_t_False(self):
@@ -418,14 +420,14 @@ class rz2psinormTestCase(unittest.TestCase):
         out_t = et.rz2psinorm(vector_R, vector_Z, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_R),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psinorm_vector_R_vector_Z_scalar_t_make_grid_True_each_t_True(self):
@@ -433,14 +435,14 @@ class rz2psinormTestCase(unittest.TestCase):
         out_t = et.rz2psinorm(vector_R, vector_Z, scalar_t, make_grid=True)
 
         self.assertEqual(out.shape, (len(vector_R), len(vector_Z)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R), len(vector_Z)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psinorm_vector_R_vector_Z_scalar_t_make_grid_False_each_t_False(self):
@@ -448,14 +450,14 @@ class rz2psinormTestCase(unittest.TestCase):
         out_t = et.rz2psinorm(vector_R, vector_Z, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_R),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psinorm_vector_R_vector_Z_scalar_t_make_grid_True_each_t_False(self):
@@ -463,14 +465,14 @@ class rz2psinormTestCase(unittest.TestCase):
         out_t = et.rz2psinorm(vector_R, vector_Z, scalar_t, make_grid=True, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_R), len(vector_Z)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R), len(vector_Z)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # matrix R, matrix Z, scalar t:
@@ -479,14 +481,14 @@ class rz2psinormTestCase(unittest.TestCase):
         out_t = et.rz2psinorm(matrix_R, matrix_Z, scalar_t)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psinorm_matrix_R_matrix_Z_scalar_t_make_grid_True_each_t_True(self):
@@ -500,14 +502,14 @@ class rz2psinormTestCase(unittest.TestCase):
         out_t = et.rz2psinorm(matrix_R, matrix_Z, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psinorm_matrix_R_matrix_Z_scalar_t_make_grid_True_each_t_False(self):
@@ -522,14 +524,14 @@ class rz2psinormTestCase(unittest.TestCase):
         out_t = et.rz2psinorm(scalar_R, scalar_Z, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psinorm_scalar_R_scalar_Z_vector_t_make_grid_True_each_t_True(self):
@@ -556,14 +558,14 @@ class rz2psinormTestCase(unittest.TestCase):
         out_t = et.rz2psinorm(vector_R, vector_Z, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_R)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_R)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psinorm_vector_R_vector_Z_vector_t_make_grid_True_each_t_True(self):
@@ -571,14 +573,14 @@ class rz2psinormTestCase(unittest.TestCase):
         out_t = et.rz2psinorm(vector_R, vector_Z, vector_t, make_grid=True)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_R), len(vector_Z)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_R), len(vector_Z)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psinorm_vector_R_vector_Z_vector_t_make_grid_False_each_t_False(self):
@@ -599,14 +601,14 @@ class rz2psinormTestCase(unittest.TestCase):
         out_t = et.rz2psinorm(matrix_R, matrix_Z, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_R.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_R.shape)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psinorm_matrix_R_matrix_Z_vector_t_make_grid_True_each_t_True(self):
@@ -645,14 +647,14 @@ class rz2psinormTestCase(unittest.TestCase):
         out_t = et.rz2psinorm(matrix_R, matrix_Z, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         # TODO: Only good to 2%.
         self.assertLessEqual(diff, 0.02)
 
@@ -674,15 +676,15 @@ class rz2phinormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2phinorm_scalar_R_scalar_Z_scalar_t_make_grid_True_each_t_True(self):
@@ -697,15 +699,15 @@ class rz2phinormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2phinorm_scalar_R_scalar_Z_scalar_t_make_grid_True_each_t_False(self):
@@ -720,15 +722,15 @@ class rz2phinormTestCase(unittest.TestCase):
         out_t = et.rz2phinorm(vector_R, vector_Z, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_R),))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R),))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2phinorm_vector_R_vector_Z_scalar_t_make_grid_True_each_t_True(self):
@@ -736,15 +738,15 @@ class rz2phinormTestCase(unittest.TestCase):
         out_t = et.rz2phinorm(vector_R, vector_Z, scalar_t, make_grid=True)
 
         self.assertEqual(out.shape, (len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2phinorm_vector_R_vector_Z_scalar_t_make_grid_False_each_t_False(self):
@@ -752,15 +754,15 @@ class rz2phinormTestCase(unittest.TestCase):
         out_t = et.rz2phinorm(vector_R, vector_Z, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_R),))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R),))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2phinorm_vector_R_vector_Z_scalar_t_make_grid_True_each_t_False(self):
@@ -768,15 +770,15 @@ class rz2phinormTestCase(unittest.TestCase):
         out_t = et.rz2phinorm(vector_R, vector_Z, scalar_t, make_grid=True, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # matrix R, matrix Z, scalar t:
@@ -785,15 +787,15 @@ class rz2phinormTestCase(unittest.TestCase):
         out_t = et.rz2phinorm(matrix_R, matrix_Z, scalar_t)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2phinorm_matrix_R_matrix_Z_scalar_t_make_grid_True_each_t_True(self):
@@ -807,15 +809,15 @@ class rz2phinormTestCase(unittest.TestCase):
         out_t = et.rz2phinorm(matrix_R, matrix_Z, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2phinorm_matrix_R_matrix_Z_scalar_t_make_grid_True_each_t_False(self):
@@ -830,14 +832,14 @@ class rz2phinormTestCase(unittest.TestCase):
         out_t = et.rz2phinorm(scalar_R, scalar_Z, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2phinorm_scalar_R_scalar_Z_vector_t_make_grid_True_each_t_True(self):
@@ -864,15 +866,15 @@ class rz2phinormTestCase(unittest.TestCase):
         out_t = et.rz2phinorm(vector_R, vector_Z, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_R)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_R)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2phinorm_vector_R_vector_Z_vector_t_make_grid_True_each_t_True(self):
@@ -880,15 +882,15 @@ class rz2phinormTestCase(unittest.TestCase):
         out_t = et.rz2phinorm(vector_R, vector_Z, vector_t, make_grid=True)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2phinorm_vector_R_vector_Z_vector_t_make_grid_False_each_t_False(self):
@@ -909,15 +911,15 @@ class rz2phinormTestCase(unittest.TestCase):
         out_t = et.rz2phinorm(matrix_R, matrix_Z, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_R.shape)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_R.shape)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2phinorm_matrix_R_matrix_Z_vector_t_make_grid_True_each_t_True(self):
@@ -956,19 +958,19 @@ class rz2phinormTestCase(unittest.TestCase):
         out_t = et.rz2phinorm(matrix_R, matrix_Z, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN point here, appears to
         # be near a coil or something.
         # TODO: Only good to 2%
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, 0.02)
 
     def test_rz2phinorm_matrix_R_matrix_Z_matrix_t_make_grid_True_each_t_False(self):
@@ -989,15 +991,15 @@ class rz2volnormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2volnorm_scalar_R_scalar_Z_scalar_t_make_grid_True_each_t_True(self):
@@ -1012,15 +1014,15 @@ class rz2volnormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2volnorm_scalar_R_scalar_Z_scalar_t_make_grid_True_each_t_False(self):
@@ -1035,15 +1037,15 @@ class rz2volnormTestCase(unittest.TestCase):
         out_t = et.rz2volnorm(vector_R, vector_Z, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_R),))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R),))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2volnorm_vector_R_vector_Z_scalar_t_make_grid_True_each_t_True(self):
@@ -1051,15 +1053,15 @@ class rz2volnormTestCase(unittest.TestCase):
         out_t = et.rz2volnorm(vector_R, vector_Z, scalar_t, make_grid=True)
 
         self.assertEqual(out.shape, (len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2volnorm_vector_R_vector_Z_scalar_t_make_grid_False_each_t_False(self):
@@ -1067,15 +1069,15 @@ class rz2volnormTestCase(unittest.TestCase):
         out_t = et.rz2volnorm(vector_R, vector_Z, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_R),))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R),))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2volnorm_vector_R_vector_Z_scalar_t_make_grid_True_each_t_False(self):
@@ -1083,15 +1085,15 @@ class rz2volnormTestCase(unittest.TestCase):
         out_t = et.rz2volnorm(vector_R, vector_Z, scalar_t, make_grid=True, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # matrix R, matrix Z, scalar t:
@@ -1100,15 +1102,15 @@ class rz2volnormTestCase(unittest.TestCase):
         out_t = et.rz2volnorm(matrix_R, matrix_Z, scalar_t)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2volnorm_matrix_R_matrix_Z_scalar_t_make_grid_True_each_t_True(self):
@@ -1122,15 +1124,15 @@ class rz2volnormTestCase(unittest.TestCase):
         out_t = et.rz2volnorm(matrix_R, matrix_Z, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2volnorm_matrix_R_matrix_Z_scalar_t_make_grid_True_each_t_False(self):
@@ -1145,14 +1147,14 @@ class rz2volnormTestCase(unittest.TestCase):
         out_t = et.rz2volnorm(scalar_R, scalar_Z, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2volnorm_scalar_R_scalar_Z_vector_t_make_grid_True_each_t_True(self):
@@ -1179,15 +1181,15 @@ class rz2volnormTestCase(unittest.TestCase):
         out_t = et.rz2volnorm(vector_R, vector_Z, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_R)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_R)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2volnorm_vector_R_vector_Z_vector_t_make_grid_True_each_t_True(self):
@@ -1195,15 +1197,15 @@ class rz2volnormTestCase(unittest.TestCase):
         out_t = et.rz2volnorm(vector_R, vector_Z, vector_t, make_grid=True)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2volnorm_vector_R_vector_Z_vector_t_make_grid_False_each_t_False(self):
@@ -1224,15 +1226,15 @@ class rz2volnormTestCase(unittest.TestCase):
         out_t = et.rz2volnorm(matrix_R, matrix_Z, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_R.shape)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_R.shape)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2volnorm_matrix_R_matrix_Z_vector_t_make_grid_True_each_t_True(self):
@@ -1271,19 +1273,19 @@ class rz2volnormTestCase(unittest.TestCase):
         out_t = et.rz2volnorm(matrix_R, matrix_Z, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN point here, appears to
         # be near a coil or something.
         # TODO: Only good to 2%.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, 0.02)
 
     def test_rz2volnorm_matrix_R_matrix_Z_matrix_t_make_grid_True_each_t_False(self):
@@ -1304,15 +1306,15 @@ class rz2rmidTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_scalar_R_scalar_Z_scalar_t_make_grid_True_each_t_True_rho_False(self):
@@ -1327,15 +1329,15 @@ class rz2rmidTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_scalar_R_scalar_Z_scalar_t_make_grid_True_each_t_False_rho_False(self):
@@ -1350,15 +1352,15 @@ class rz2rmidTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_scalar_R_scalar_Z_scalar_t_make_grid_True_each_t_True_rho_True(self):
@@ -1373,15 +1375,15 @@ class rz2rmidTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_scalar_R_scalar_Z_scalar_t_make_grid_True_each_t_False_rho_True(self):
@@ -1396,15 +1398,15 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(vector_R, vector_Z, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_R),))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R),))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_vector_R_vector_Z_scalar_t_make_grid_True_each_t_True_rho_False(self):
@@ -1412,17 +1414,17 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(vector_R, vector_Z, scalar_t, make_grid=True)
 
         self.assertEqual(out.shape, (len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN two points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_vector_R_vector_Z_scalar_t_make_grid_False_each_t_False_rho_False(self):
@@ -1430,15 +1432,15 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(vector_R, vector_Z, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_R),))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R),))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_vector_R_vector_Z_scalar_t_make_grid_True_each_t_False_rho_False(self):
@@ -1446,17 +1448,17 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(vector_R, vector_Z, scalar_t, make_grid=True, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN two points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_vector_R_vector_Z_scalar_t_make_grid_False_each_t_True_rho_True(self):
@@ -1464,15 +1466,15 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(vector_R, vector_Z, scalar_t, rho=True)
 
         self.assertEqual(out.shape, (len(vector_R),))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R),))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_vector_R_vector_Z_scalar_t_make_grid_True_each_t_True_rho_True(self):
@@ -1480,17 +1482,17 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(vector_R, vector_Z, scalar_t, make_grid=True, rho=True)
 
         self.assertEqual(out.shape, (len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN two points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_vector_R_vector_Z_scalar_t_make_grid_False_each_t_False_rho_True(self):
@@ -1498,15 +1500,15 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(vector_R, vector_Z, scalar_t, each_t=False, rho=True)
 
         self.assertEqual(out.shape, (len(vector_R),))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R),))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_vector_R_vector_Z_scalar_t_make_grid_True_each_t_False_rho_True(self):
@@ -1514,17 +1516,17 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(vector_R, vector_Z, scalar_t, make_grid=True, each_t=False, rho=True)
 
         self.assertEqual(out.shape, (len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN two points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # matrix R, matrix Z, scalar t:
@@ -1533,17 +1535,17 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(matrix_R, matrix_Z, scalar_t)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN two points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_matrix_R_matrix_Z_scalar_t_make_grid_True_each_t_True_rho_False(self):
@@ -1557,17 +1559,17 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(matrix_R, matrix_Z, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN two points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_matrix_R_matrix_Z_scalar_t_make_grid_True_each_t_False_rho_False(self):
@@ -1581,17 +1583,17 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(matrix_R, matrix_Z, scalar_t, rho=True)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN two points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_matrix_R_matrix_Z_scalar_t_make_grid_True_each_t_True_rho_True(self):
@@ -1605,17 +1607,17 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(matrix_R, matrix_Z, scalar_t, each_t=False, rho=True)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN two points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_matrix_R_matrix_Z_scalar_t_make_grid_True_each_t_False_rho_True(self):
@@ -1630,14 +1632,14 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(scalar_R, scalar_Z, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_scalar_R_scalar_Z_vector_t_make_grid_True_each_t_True_rho_False(self):
@@ -1663,14 +1665,14 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(scalar_R, scalar_Z, vector_t, rho=True)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_scalar_R_scalar_Z_vector_t_make_grid_True_each_t_True_rho_True(self):
@@ -1697,17 +1699,17 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(vector_R, vector_Z, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_R)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_R)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN ten points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_vector_R_vector_Z_vector_t_make_grid_True_each_t_True_rho_False(self):
@@ -1715,17 +1717,17 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(vector_R, vector_Z, vector_t, make_grid=True)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN 289 points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_vector_R_vector_Z_vector_t_make_grid_False_each_t_False_rho_False(self):
@@ -1745,17 +1747,17 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(vector_R, vector_Z, vector_t, rho=True)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_R)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_R)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN ten points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_vector_R_vector_Z_vector_t_make_grid_True_each_t_True_rho_True(self):
@@ -1763,17 +1765,17 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(vector_R, vector_Z, vector_t, make_grid=True, rho=True)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN 289 points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_vector_R_vector_Z_vector_t_make_grid_False_each_t_False_rho_True(self):
@@ -1794,17 +1796,17 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(matrix_R, matrix_Z, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_R.shape)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_R.shape)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN 289 points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_matrix_R_matrix_Z_vector_t_make_grid_True_each_t_True_rho_False(self):
@@ -1830,17 +1832,17 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(matrix_R, matrix_Z, vector_t, rho=True)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_R.shape)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_R.shape)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN 289 points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_matrix_R_matrix_Z_vector_t_make_grid_True_each_t_True_rho_True(self):
@@ -1879,17 +1881,17 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(matrix_R, matrix_Z, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN seven points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2rmid_matrix_R_matrix_Z_matrix_t_make_grid_True_each_t_False_rho_False(self):
@@ -1915,18 +1917,18 @@ class rz2rmidTestCase(unittest.TestCase):
         out_t = et.rz2rmid(matrix_R, matrix_Z, matrix_t, each_t=False, rho=True)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN seven points here.
         # TODO: Why is this only good to 3%?
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, 0.03)
 
     def test_rz2rmid_matrix_R_matrix_Z_matrix_t_make_grid_True_each_t_False_rho_True(self):
@@ -1947,15 +1949,15 @@ class rz2roaTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2roa_scalar_R_scalar_Z_scalar_t_make_grid_True_each_t_True(self):
@@ -1970,15 +1972,15 @@ class rz2roaTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2roa_scalar_R_scalar_Z_scalar_t_make_grid_True_each_t_False(self):
@@ -1993,15 +1995,15 @@ class rz2roaTestCase(unittest.TestCase):
         out_t = et.rz2roa(vector_R, vector_Z, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_R),))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R),))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2roa_vector_R_vector_Z_scalar_t_make_grid_True_each_t_True(self):
@@ -2009,17 +2011,17 @@ class rz2roaTestCase(unittest.TestCase):
         out_t = et.rz2roa(vector_R, vector_Z, scalar_t, make_grid=True)
 
         self.assertEqual(out.shape, (len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN two points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2roa_vector_R_vector_Z_scalar_t_make_grid_False_each_t_False(self):
@@ -2027,15 +2029,15 @@ class rz2roaTestCase(unittest.TestCase):
         out_t = et.rz2roa(vector_R, vector_Z, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_R),))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R),))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2roa_vector_R_vector_Z_scalar_t_make_grid_True_each_t_False(self):
@@ -2043,17 +2045,17 @@ class rz2roaTestCase(unittest.TestCase):
         out_t = et.rz2roa(vector_R, vector_Z, scalar_t, make_grid=True, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN two points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # matrix R, matrix Z, scalar t:
@@ -2062,17 +2064,17 @@ class rz2roaTestCase(unittest.TestCase):
         out_t = et.rz2roa(matrix_R, matrix_Z, scalar_t)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN two points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2roa_matrix_R_matrix_Z_scalar_t_make_grid_True_each_t_True(self):
@@ -2086,17 +2088,17 @@ class rz2roaTestCase(unittest.TestCase):
         out_t = et.rz2roa(matrix_R, matrix_Z, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN two points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2roa_matrix_R_matrix_Z_scalar_t_make_grid_True_each_t_False(self):
@@ -2111,14 +2113,14 @@ class rz2roaTestCase(unittest.TestCase):
         out_t = et.rz2roa(scalar_R, scalar_Z, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2roa_scalar_R_scalar_Z_vector_t_make_grid_True_each_t_True(self):
@@ -2145,17 +2147,17 @@ class rz2roaTestCase(unittest.TestCase):
         out_t = et.rz2roa(vector_R, vector_Z, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_R)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_R)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN ten points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2roa_vector_R_vector_Z_vector_t_make_grid_True_each_t_True(self):
@@ -2163,17 +2165,17 @@ class rz2roaTestCase(unittest.TestCase):
         out_t = et.rz2roa(vector_R, vector_Z, vector_t, make_grid=True)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_R), len(vector_Z)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN 289 points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2roa_vector_R_vector_Z_vector_t_make_grid_False_each_t_False(self):
@@ -2194,17 +2196,17 @@ class rz2roaTestCase(unittest.TestCase):
         out_t = et.rz2roa(matrix_R, matrix_Z, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_R.shape)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_R.shape)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN 289 points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2roa_matrix_R_matrix_Z_vector_t_make_grid_True_each_t_True(self):
@@ -2243,18 +2245,18 @@ class rz2roaTestCase(unittest.TestCase):
         out_t = et.rz2roa(matrix_R, matrix_Z, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_R.shape)
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra non-NaN 7 points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # TODO: Why is this only good to 3%?
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, 0.03)
 
     def test_rz2roa_matrix_R_matrix_Z_matrix_t_make_grid_True_each_t_False(self):
@@ -2275,15 +2277,15 @@ class rmid2roaTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2roa_scalar_Rmid_scalar_t_each_t_False(self):
@@ -2292,15 +2294,15 @@ class rmid2roaTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # vector Rmid, scalar t:
@@ -2309,14 +2311,14 @@ class rmid2roaTestCase(unittest.TestCase):
         out_t = et.rmid2roa(vector_Rmid, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_Rmid),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_Rmid),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2roa_vector_Rmid_scalar_t_each_t_False(self):
@@ -2324,14 +2326,14 @@ class rmid2roaTestCase(unittest.TestCase):
         out_t = et.rmid2roa(vector_Rmid, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_Rmid),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_Rmid),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # matrix Rmid, scalar t:
@@ -2340,14 +2342,14 @@ class rmid2roaTestCase(unittest.TestCase):
         out_t = et.rmid2roa(matrix_Rmid, scalar_t)
 
         self.assertEqual(out.shape, matrix_Rmid.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_Rmid.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2roa_matrix_Rmid_scalar_t_each_t_False(self):
@@ -2355,14 +2357,14 @@ class rmid2roaTestCase(unittest.TestCase):
         out_t = et.rmid2roa(matrix_Rmid, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_Rmid.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_Rmid.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # scalar Rmid, vector t:
@@ -2371,14 +2373,14 @@ class rmid2roaTestCase(unittest.TestCase):
         out_t = et.rmid2roa(scalar_Rmid, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2roa_scalar_Rmid_vector_t_each_t_False(self):
@@ -2393,14 +2395,14 @@ class rmid2roaTestCase(unittest.TestCase):
         out_t = et.rmid2roa(vector_Rmid, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_Rmid)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_Rmid)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2roa_vector_Rmid_vector_t_each_t_False(self):
@@ -2415,14 +2417,14 @@ class rmid2roaTestCase(unittest.TestCase):
         out_t = et.rmid2roa(matrix_Rmid, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_Rmid.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_Rmid.shape)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2roa_matrix_Rmid_vector_t_each_t_False(self):
@@ -2443,15 +2445,15 @@ class rmid2roaTestCase(unittest.TestCase):
         out_t = et.rmid2roa(matrix_Rmid, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_Rmid.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_Rmid.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: Only good to 2%.
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, 0.02)
 
 class rmid2psinormTestCase(unittest.TestCase):
@@ -2466,15 +2468,15 @@ class rmid2psinormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2psinorm_scalar_psinorm_scalar_t_each_t_False(self):
@@ -2483,15 +2485,15 @@ class rmid2psinormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # vector Rmid, scalar t:
@@ -2500,14 +2502,14 @@ class rmid2psinormTestCase(unittest.TestCase):
         out_t = et.rmid2psinorm(vector_Rmid, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_Rmid),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_Rmid),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2psinorm_vector_psinorm_scalar_t_each_t_False(self):
@@ -2515,14 +2517,14 @@ class rmid2psinormTestCase(unittest.TestCase):
         out_t = et.rmid2psinorm(vector_Rmid, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_Rmid),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_Rmid),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # matrix Rmid, scalar t:
@@ -2531,14 +2533,14 @@ class rmid2psinormTestCase(unittest.TestCase):
         out_t = et.rmid2psinorm(matrix_Rmid, scalar_t)
 
         self.assertEqual(out.shape, matrix_Rmid.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_Rmid.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2psinorm_matrix_psinorm_scalar_t_each_t_False(self):
@@ -2546,14 +2548,14 @@ class rmid2psinormTestCase(unittest.TestCase):
         out_t = et.rmid2psinorm(matrix_Rmid, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_Rmid.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_Rmid.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # scalar Rmid, vector t:
@@ -2562,14 +2564,14 @@ class rmid2psinormTestCase(unittest.TestCase):
         out_t = et.rmid2psinorm(scalar_Rmid, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2psinorm_scalar_psinorm_vector_t_each_t_False(self):
@@ -2584,14 +2586,14 @@ class rmid2psinormTestCase(unittest.TestCase):
         out_t = et.rmid2psinorm(vector_Rmid, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_Rmid)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_Rmid)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2psinorm_vector_psinorm_vector_t_each_t_False(self):
@@ -2606,14 +2608,14 @@ class rmid2psinormTestCase(unittest.TestCase):
         out_t = et.rmid2psinorm(matrix_Rmid, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_Rmid.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_Rmid.shape)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2psinorm_matrix_psinorm_vector_t_each_t_False(self):
@@ -2634,15 +2636,15 @@ class rmid2psinormTestCase(unittest.TestCase):
         out_t = et.rmid2psinorm(matrix_Rmid, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_Rmid.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_Rmid.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: Only good to 2%.
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, 0.02)
 
 class rmid2phinormTestCase(unittest.TestCase):
@@ -2657,15 +2659,15 @@ class rmid2phinormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2phinorm_scalar_psinorm_scalar_t_each_t_False(self):
@@ -2674,15 +2676,15 @@ class rmid2phinormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # vector Rmid, scalar t:
@@ -2691,15 +2693,15 @@ class rmid2phinormTestCase(unittest.TestCase):
         out_t = et.rmid2phinorm(vector_Rmid, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_Rmid),))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_Rmid),))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2phinorm_vector_psinorm_scalar_t_each_t_False(self):
@@ -2707,15 +2709,15 @@ class rmid2phinormTestCase(unittest.TestCase):
         out_t = et.rmid2phinorm(vector_Rmid, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_Rmid),))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_Rmid),))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # matrix Rmid, scalar t:
@@ -2724,15 +2726,15 @@ class rmid2phinormTestCase(unittest.TestCase):
         out_t = et.rmid2phinorm(matrix_Rmid, scalar_t)
 
         self.assertEqual(out.shape, matrix_Rmid.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out.shape, matrix_Rmid.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2phinorm_matrix_psinorm_scalar_t_each_t_False(self):
@@ -2740,15 +2742,15 @@ class rmid2phinormTestCase(unittest.TestCase):
         out_t = et.rmid2phinorm(matrix_Rmid, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_Rmid.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_Rmid.shape)
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # scalar Rmid, vector t:
@@ -2757,14 +2759,14 @@ class rmid2phinormTestCase(unittest.TestCase):
         out_t = et.rmid2phinorm(scalar_Rmid, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2phinorm_scalar_psinorm_vector_t_each_t_False(self):
@@ -2779,17 +2781,17 @@ class rmid2phinormTestCase(unittest.TestCase):
         out_t = et.rmid2phinorm(vector_Rmid, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_Rmid)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_Rmid)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra 1 non-NaN points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2phinorm_vector_psinorm_vector_t_each_t_False(self):
@@ -2804,17 +2806,17 @@ class rmid2phinormTestCase(unittest.TestCase):
         out_t = et.rmid2phinorm(matrix_Rmid, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_Rmid.shape)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_Rmid.shape)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra 25 non-NaN points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2phinorm_matrix_psinorm_vector_t_each_t_False(self):
@@ -2835,18 +2837,18 @@ class rmid2phinormTestCase(unittest.TestCase):
         out_t = et.rmid2phinorm(matrix_Rmid, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_Rmid.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_Rmid.shape)
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra 1 non-NaN points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # TODO: Only good to 2%.
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, 0.02)
 
 class rmid2volnormTestCase(unittest.TestCase):
@@ -2861,15 +2863,15 @@ class rmid2volnormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2volnorm_scalar_psinorm_scalar_t_each_t_False(self):
@@ -2878,15 +2880,15 @@ class rmid2volnormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # vector Rmid, scalar t:
@@ -2895,15 +2897,15 @@ class rmid2volnormTestCase(unittest.TestCase):
         out_t = et.rmid2volnorm(vector_Rmid, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_Rmid),))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_Rmid),))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2volnorm_vector_psinorm_scalar_t_each_t_False(self):
@@ -2911,15 +2913,15 @@ class rmid2volnormTestCase(unittest.TestCase):
         out_t = et.rmid2volnorm(vector_Rmid, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_Rmid),))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_Rmid),))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # matrix Rmid, scalar t:
@@ -2928,15 +2930,15 @@ class rmid2volnormTestCase(unittest.TestCase):
         out_t = et.rmid2volnorm(matrix_Rmid, scalar_t)
 
         self.assertEqual(out.shape, matrix_Rmid.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_Rmid.shape)
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2volnorm_matrix_psinorm_scalar_t_each_t_False(self):
@@ -2944,15 +2946,15 @@ class rmid2volnormTestCase(unittest.TestCase):
         out_t = et.rmid2volnorm(matrix_Rmid, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_Rmid.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_Rmid.shape)
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
-        diff = scipy.sqrt(((out[~scipy.isnan(out)] - out_t[~scipy.isnan(out)])**2).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out[~numpy.isnan(out)] - out_t[~numpy.isnan(out)])**2).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # scalar Rmid, vector t:
@@ -2961,14 +2963,14 @@ class rmid2volnormTestCase(unittest.TestCase):
         out_t = et.rmid2volnorm(scalar_Rmid, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2volnorm_scalar_psinorm_vector_t_each_t_False(self):
@@ -2983,17 +2985,17 @@ class rmid2volnormTestCase(unittest.TestCase):
         out_t = et.rmid2volnorm(vector_Rmid, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_Rmid)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_Rmid)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra 1 non-NaN points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2volnorm_vector_psinorm_vector_t_each_t_False(self):
@@ -3008,17 +3010,17 @@ class rmid2volnormTestCase(unittest.TestCase):
         out_t = et.rmid2volnorm(matrix_Rmid, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_Rmid.shape)))
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_Rmid.shape)))
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra 25 non-NaN points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_rmid2volnorm_matrix_psinorm_vector_t_each_t_False(self):
@@ -3039,18 +3041,18 @@ class rmid2volnormTestCase(unittest.TestCase):
         out_t = et.rmid2volnorm(matrix_Rmid, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_Rmid.shape)
-        self.assertTrue(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertTrue(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_Rmid.shape)
-        self.assertTrue(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertTrue(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
         # TODO: The trispline case has an extra 1 non-NaN points here.
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # TODO: Only good to 2%.
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, 0.02)
 
 class roa2rmidTestCase(unittest.TestCase):
@@ -3065,15 +3067,15 @@ class roa2rmidTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2rmid_scalar_psinorm_scalar_t_each_t_False(self):
@@ -3082,15 +3084,15 @@ class roa2rmidTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # vector r/a, scalar t:
@@ -3099,14 +3101,14 @@ class roa2rmidTestCase(unittest.TestCase):
         out_t = et.roa2rmid(vector_psinorm, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2rmid_vector_psinorm_scalar_t_each_t_False(self):
@@ -3114,14 +3116,14 @@ class roa2rmidTestCase(unittest.TestCase):
         out_t = et.roa2rmid(vector_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # matrix r/a, scalar t:
@@ -3130,14 +3132,14 @@ class roa2rmidTestCase(unittest.TestCase):
         out_t = et.roa2rmid(matrix_psinorm, scalar_t)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2rmid_matrix_psinorm_scalar_t_each_t_False(self):
@@ -3145,14 +3147,14 @@ class roa2rmidTestCase(unittest.TestCase):
         out_t = et.roa2rmid(matrix_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # scalar r/a, vector t:
@@ -3161,14 +3163,14 @@ class roa2rmidTestCase(unittest.TestCase):
         out_t = et.roa2rmid(scalar_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2rmid_scalar_psinorm_vector_t_each_t_False(self):
@@ -3183,14 +3185,14 @@ class roa2rmidTestCase(unittest.TestCase):
         out_t = et.roa2rmid(vector_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2rmid_vector_psinorm_vector_t_each_t_False(self):
@@ -3205,14 +3207,14 @@ class roa2rmidTestCase(unittest.TestCase):
         out_t = et.roa2rmid(matrix_psinorm, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2rmid_matrix_psinorm_vector_t_each_t_False(self):
@@ -3233,14 +3235,14 @@ class roa2rmidTestCase(unittest.TestCase):
         out_t = et.roa2rmid(matrix_psinorm, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
 class roa2psinormTestCase(unittest.TestCase):
@@ -3255,15 +3257,15 @@ class roa2psinormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2psinorm_scalar_psinorm_scalar_t_each_t_False(self):
@@ -3272,15 +3274,15 @@ class roa2psinormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # vector r/a, scalar t:
@@ -3289,14 +3291,14 @@ class roa2psinormTestCase(unittest.TestCase):
         out_t = et.roa2psinorm(vector_psinorm, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2psinorm_vector_psinorm_scalar_t_each_t_False(self):
@@ -3304,14 +3306,14 @@ class roa2psinormTestCase(unittest.TestCase):
         out_t = et.roa2psinorm(vector_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # matrix r/a, scalar t:
@@ -3320,14 +3322,14 @@ class roa2psinormTestCase(unittest.TestCase):
         out_t = et.roa2psinorm(matrix_psinorm, scalar_t)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2psinorm_matrix_psinorm_scalar_t_each_t_False(self):
@@ -3335,14 +3337,14 @@ class roa2psinormTestCase(unittest.TestCase):
         out_t = et.roa2psinorm(matrix_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # scalar r/a, vector t:
@@ -3351,14 +3353,14 @@ class roa2psinormTestCase(unittest.TestCase):
         out_t = et.roa2psinorm(scalar_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2psinorm_scalar_psinorm_vector_t_each_t_False(self):
@@ -3373,14 +3375,14 @@ class roa2psinormTestCase(unittest.TestCase):
         out_t = et.roa2psinorm(vector_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2psinorm_vector_psinorm_vector_t_each_t_False(self):
@@ -3395,14 +3397,14 @@ class roa2psinormTestCase(unittest.TestCase):
         out_t = et.roa2psinorm(matrix_psinorm, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2psinorm_matrix_psinorm_vector_t_each_t_False(self):
@@ -3423,14 +3425,14 @@ class roa2psinormTestCase(unittest.TestCase):
         out_t = et.roa2psinorm(matrix_psinorm, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
 class roa2phinormTestCase(unittest.TestCase):
@@ -3445,15 +3447,15 @@ class roa2phinormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2phinorm_scalar_psinorm_scalar_t_each_t_False(self):
@@ -3462,15 +3464,15 @@ class roa2phinormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # vector r/a, scalar t:
@@ -3479,14 +3481,14 @@ class roa2phinormTestCase(unittest.TestCase):
         out_t = et.roa2phinorm(vector_psinorm, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2phinorm_vector_psinorm_scalar_t_each_t_False(self):
@@ -3494,14 +3496,14 @@ class roa2phinormTestCase(unittest.TestCase):
         out_t = et.roa2phinorm(vector_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # matrix r/a, scalar t:
@@ -3510,14 +3512,14 @@ class roa2phinormTestCase(unittest.TestCase):
         out_t = et.roa2phinorm(matrix_psinorm, scalar_t)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2phinorm_matrix_psinorm_scalar_t_each_t_False(self):
@@ -3525,14 +3527,14 @@ class roa2phinormTestCase(unittest.TestCase):
         out_t = et.roa2phinorm(matrix_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # scalar r/a, vector t:
@@ -3541,14 +3543,14 @@ class roa2phinormTestCase(unittest.TestCase):
         out_t = et.roa2phinorm(scalar_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2phinorm_scalar_psinorm_vector_t_each_t_False(self):
@@ -3564,18 +3566,18 @@ class roa2phinormTestCase(unittest.TestCase):
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_psinorm)))
         # TODO: Fix boundaries!
-        # self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        # self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_psinorm)))
         # TODO: Fix boundaries!
-        # self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        # self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2phinorm_vector_psinorm_vector_t_each_t_False(self):
@@ -3591,18 +3593,18 @@ class roa2phinormTestCase(unittest.TestCase):
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
         # TODO: Fix boundaries!
-        # self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        # self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
         # TODO: Fix boundaries!
-        # self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        # self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2phinorm_matrix_psinorm_vector_t_each_t_False(self):
@@ -3624,18 +3626,18 @@ class roa2phinormTestCase(unittest.TestCase):
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
         # TODO: Fix boundaries!
-        # self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        # self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
         # TODO: Fix boundaries!
-        # self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        # self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
 class roa2volnormTestCase(unittest.TestCase):
@@ -3650,15 +3652,15 @@ class roa2volnormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2volnorm_scalar_psinorm_scalar_t_each_t_False(self):
@@ -3667,15 +3669,15 @@ class roa2volnormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # vector r/a, scalar t:
@@ -3684,14 +3686,14 @@ class roa2volnormTestCase(unittest.TestCase):
         out_t = et.roa2volnorm(vector_psinorm, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2volnorm_vector_psinorm_scalar_t_each_t_False(self):
@@ -3699,14 +3701,14 @@ class roa2volnormTestCase(unittest.TestCase):
         out_t = et.roa2volnorm(vector_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # matrix r/a, scalar t:
@@ -3715,14 +3717,14 @@ class roa2volnormTestCase(unittest.TestCase):
         out_t = et.roa2volnorm(matrix_psinorm, scalar_t)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2volnorm_matrix_psinorm_scalar_t_each_t_False(self):
@@ -3730,14 +3732,14 @@ class roa2volnormTestCase(unittest.TestCase):
         out_t = et.roa2volnorm(matrix_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # scalar r/a, vector t:
@@ -3746,14 +3748,14 @@ class roa2volnormTestCase(unittest.TestCase):
         out_t = et.roa2volnorm(scalar_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2volnorm_scalar_psinorm_vector_t_each_t_False(self):
@@ -3769,18 +3771,18 @@ class roa2volnormTestCase(unittest.TestCase):
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_psinorm)))
         # TODO: Fix boundaries!
-        # self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        # self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_psinorm)))
         # TODO: Fix boundaries!
-        # self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        # self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2volnorm_vector_psinorm_vector_t_each_t_False(self):
@@ -3796,18 +3798,18 @@ class roa2volnormTestCase(unittest.TestCase):
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
         # TODO: Fix boundaries!
-        # self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        # self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
         # TODO: Fix boundaries!
-        # self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        # self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2volnorm_matrix_psinorm_vector_t_each_t_False(self):
@@ -3829,18 +3831,18 @@ class roa2volnormTestCase(unittest.TestCase):
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
         # TODO: Fix boundaries!
-        # self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        # self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
         # TODO: Fix boundaries!
-        # self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        # self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
 class psinorm2rmidTestCase(unittest.TestCase):
@@ -3855,15 +3857,15 @@ class psinorm2rmidTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2rmid_scalar_psinorm_scalar_t_each_t_False_rho_False(self):
@@ -3872,15 +3874,15 @@ class psinorm2rmidTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2rmid_scalar_psinorm_scalar_t_each_t_True_rho_True(self):
@@ -3889,15 +3891,15 @@ class psinorm2rmidTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2rmid_scalar_psinorm_scalar_t_each_t_False_rho_True(self):
@@ -3906,15 +3908,15 @@ class psinorm2rmidTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # vector psinorm, scalar t:
@@ -3923,17 +3925,17 @@ class psinorm2rmidTestCase(unittest.TestCase):
         out_t = et.psinorm2rmid(vector_psinorm, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2rmid_vector_psinorm_scalar_t_each_t_False_rho_False(self):
@@ -3941,17 +3943,17 @@ class psinorm2rmidTestCase(unittest.TestCase):
         out_t = et.psinorm2rmid(vector_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2rmid_vector_psinorm_scalar_t_each_t_True_rho_True(self):
@@ -3959,17 +3961,17 @@ class psinorm2rmidTestCase(unittest.TestCase):
         out_t = et.psinorm2rmid(vector_psinorm, scalar_t, rho=True)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2rmid_vector_psinorm_scalar_t_each_t_False_rho_True(self):
@@ -3977,17 +3979,17 @@ class psinorm2rmidTestCase(unittest.TestCase):
         out_t = et.psinorm2rmid(vector_psinorm, scalar_t, each_t=False, rho=True)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # matrix psinorm, scalar t:
@@ -3996,17 +3998,17 @@ class psinorm2rmidTestCase(unittest.TestCase):
         out_t = et.psinorm2rmid(matrix_psinorm, scalar_t)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2rmid_matrix_psinorm_scalar_t_each_t_False_rho_False(self):
@@ -4014,17 +4016,17 @@ class psinorm2rmidTestCase(unittest.TestCase):
         out_t = et.psinorm2rmid(matrix_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2rmid_matrix_psinorm_scalar_t_each_t_True_rho_True(self):
@@ -4032,17 +4034,17 @@ class psinorm2rmidTestCase(unittest.TestCase):
         out_t = et.psinorm2rmid(matrix_psinorm, scalar_t, rho=True)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2rmid_matrix_psinorm_scalar_t_each_t_False_rho_True(self):
@@ -4050,17 +4052,17 @@ class psinorm2rmidTestCase(unittest.TestCase):
         out_t = et.psinorm2rmid(matrix_psinorm, scalar_t, each_t=False, rho=True)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # scalar psinorm, vector t:
@@ -4069,14 +4071,14 @@ class psinorm2rmidTestCase(unittest.TestCase):
         out_t = et.psinorm2rmid(scalar_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2rmid_scalar_psinorm_vector_t_each_t_False_rho_False(self):
@@ -4090,14 +4092,14 @@ class psinorm2rmidTestCase(unittest.TestCase):
         out_t = et.psinorm2rmid(scalar_psinorm, vector_t, rho=True)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2rmid_scalar_psinorm_vector_t_each_t_False_rho_True(self):
@@ -4112,17 +4114,17 @@ class psinorm2rmidTestCase(unittest.TestCase):
         out_t = et.psinorm2rmid(vector_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2rmid_vector_psinorm_vector_t_each_t_False_rho_False(self):
@@ -4136,17 +4138,17 @@ class psinorm2rmidTestCase(unittest.TestCase):
         out_t = et.psinorm2rmid(vector_psinorm, vector_t, rho=True)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2rmid_vector_psinorm_vector_t_each_t_False_rho_True(self):
@@ -4161,17 +4163,17 @@ class psinorm2rmidTestCase(unittest.TestCase):
         out_t = et.psinorm2rmid(matrix_psinorm, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2rmid_matrix_psinorm_vector_t_each_t_False_rho_False(self):
@@ -4185,17 +4187,17 @@ class psinorm2rmidTestCase(unittest.TestCase):
         out_t = et.psinorm2rmid(matrix_psinorm, vector_t, rho=True)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2rmid_matrix_psinorm_vector_t_each_t_False_rho_True(self):
@@ -4216,17 +4218,17 @@ class psinorm2rmidTestCase(unittest.TestCase):
         out_t = et.psinorm2rmid(matrix_psinorm, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2rmid_matrix_psinorm_matrix_t_each_t_True_rho_True(self):
@@ -4240,17 +4242,17 @@ class psinorm2rmidTestCase(unittest.TestCase):
         out_t = et.psinorm2rmid(matrix_psinorm, matrix_t, each_t=False, rho=True)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
 class psinorm2roaTestCase(unittest.TestCase):
@@ -4265,15 +4267,15 @@ class psinorm2roaTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2roa_scalar_psinorm_scalar_t_each_t_False(self):
@@ -4282,15 +4284,15 @@ class psinorm2roaTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # vector psinorm, scalar t:
@@ -4299,17 +4301,17 @@ class psinorm2roaTestCase(unittest.TestCase):
         out_t = et.psinorm2roa(vector_psinorm, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2roa_vector_psinorm_scalar_t_each_t_False(self):
@@ -4317,17 +4319,17 @@ class psinorm2roaTestCase(unittest.TestCase):
         out_t = et.psinorm2roa(vector_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # matrix psinorm, scalar t:
@@ -4336,17 +4338,17 @@ class psinorm2roaTestCase(unittest.TestCase):
         out_t = et.psinorm2roa(matrix_psinorm, scalar_t)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2roa_matrix_psinorm_scalar_t_each_t_False(self):
@@ -4354,17 +4356,17 @@ class psinorm2roaTestCase(unittest.TestCase):
         out_t = et.psinorm2roa(matrix_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # scalar psinorm, vector t:
@@ -4373,14 +4375,14 @@ class psinorm2roaTestCase(unittest.TestCase):
         out_t = et.psinorm2roa(scalar_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2roa_scalar_psinorm_vector_t_each_t_False(self):
@@ -4395,17 +4397,17 @@ class psinorm2roaTestCase(unittest.TestCase):
         out_t = et.psinorm2roa(vector_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2roa_vector_psinorm_vector_t_each_t_False(self):
@@ -4420,17 +4422,17 @@ class psinorm2roaTestCase(unittest.TestCase):
         out_t = et.psinorm2roa(matrix_psinorm, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2roa_matrix_psinorm_vector_t_each_t_False(self):
@@ -4451,17 +4453,17 @@ class psinorm2roaTestCase(unittest.TestCase):
         out_t = et.psinorm2roa(matrix_psinorm, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
 class psinorm2volnormTestCase(unittest.TestCase):
@@ -4476,15 +4478,15 @@ class psinorm2volnormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2volnorm_scalar_psinorm_scalar_t_each_t_False(self):
@@ -4493,15 +4495,15 @@ class psinorm2volnormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # vector psinorm, scalar t:
@@ -4510,14 +4512,14 @@ class psinorm2volnormTestCase(unittest.TestCase):
         out_t = et.psinorm2volnorm(vector_psinorm, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2volnorm_vector_psinorm_scalar_t_each_t_False(self):
@@ -4525,14 +4527,14 @@ class psinorm2volnormTestCase(unittest.TestCase):
         out_t = et.psinorm2volnorm(vector_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # matrix psinorm, scalar t:
@@ -4541,14 +4543,14 @@ class psinorm2volnormTestCase(unittest.TestCase):
         out_t = et.psinorm2volnorm(matrix_psinorm, scalar_t)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2volnorm_matrix_psinorm_scalar_t_each_t_False(self):
@@ -4556,14 +4558,14 @@ class psinorm2volnormTestCase(unittest.TestCase):
         out_t = et.psinorm2volnorm(matrix_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # scalar psinorm, vector t:
@@ -4572,14 +4574,14 @@ class psinorm2volnormTestCase(unittest.TestCase):
         out_t = et.psinorm2volnorm(scalar_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2volnorm_scalar_psinorm_vector_t_each_t_False(self):
@@ -4594,14 +4596,14 @@ class psinorm2volnormTestCase(unittest.TestCase):
         out_t = et.psinorm2volnorm(vector_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2volnorm_vector_psinorm_vector_t_each_t_False(self):
@@ -4616,14 +4618,14 @@ class psinorm2volnormTestCase(unittest.TestCase):
         out_t = et.psinorm2volnorm(matrix_psinorm, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2volnorm_matrix_psinorm_vector_t_each_t_False(self):
@@ -4644,14 +4646,14 @@ class psinorm2volnormTestCase(unittest.TestCase):
         out_t = et.psinorm2volnorm(matrix_psinorm, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
 class psinorm2phinormTestCase(unittest.TestCase):
@@ -4666,15 +4668,15 @@ class psinorm2phinormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2phinorm_scalar_psinorm_scalar_t_each_t_False(self):
@@ -4683,15 +4685,15 @@ class psinorm2phinormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # vector psinorm, scalar t:
@@ -4700,14 +4702,14 @@ class psinorm2phinormTestCase(unittest.TestCase):
         out_t = e.psinorm2phinorm(vector_psinorm, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2phinorm_vector_psinorm_scalar_t_each_t_False(self):
@@ -4715,14 +4717,14 @@ class psinorm2phinormTestCase(unittest.TestCase):
         out_t = et.psinorm2phinorm(vector_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # matrix psinorm, scalar t:
@@ -4731,14 +4733,14 @@ class psinorm2phinormTestCase(unittest.TestCase):
         out_t = et.psinorm2phinorm(matrix_psinorm, scalar_t)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2phinorm_matrix_psinorm_scalar_t_each_t_False(self):
@@ -4746,14 +4748,14 @@ class psinorm2phinormTestCase(unittest.TestCase):
         out_t = et.psinorm2phinorm(matrix_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # scalar psinorm, vector t:
@@ -4762,14 +4764,14 @@ class psinorm2phinormTestCase(unittest.TestCase):
         out_t = et.psinorm2phinorm(scalar_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2phinorm_scalar_psinorm_vector_t_each_t_False(self):
@@ -4784,14 +4786,14 @@ class psinorm2phinormTestCase(unittest.TestCase):
         out_t = et.psinorm2phinorm(vector_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2phinorm_vector_psinorm_vector_t_each_t_False(self):
@@ -4806,14 +4808,14 @@ class psinorm2phinormTestCase(unittest.TestCase):
         out_t = et.psinorm2phinorm(matrix_psinorm, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2phinorm_matrix_psinorm_vector_t_each_t_False(self):
@@ -4834,14 +4836,14 @@ class psinorm2phinormTestCase(unittest.TestCase):
         out_t = et.psinorm2phinorm(matrix_psinorm, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
 class phinorm2psinormTestCase(unittest.TestCase):
@@ -4856,15 +4858,15 @@ class phinorm2psinormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2psinorm_scalar_psinorm_scalar_t_each_t_False(self):
@@ -4873,15 +4875,15 @@ class phinorm2psinormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # vector psinorm, scalar t:
@@ -4890,14 +4892,14 @@ class phinorm2psinormTestCase(unittest.TestCase):
         out_t = et.phinorm2psinorm(vector_psinorm, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2psinorm_vector_psinorm_scalar_t_each_t_False(self):
@@ -4905,14 +4907,14 @@ class phinorm2psinormTestCase(unittest.TestCase):
         out_t = et.phinorm2psinorm(vector_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # matrix psinorm, scalar t:
@@ -4921,14 +4923,14 @@ class phinorm2psinormTestCase(unittest.TestCase):
         out_t = et.phinorm2psinorm(matrix_psinorm, scalar_t)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2psinorm_matrix_psinorm_scalar_t_each_t_False(self):
@@ -4936,14 +4938,14 @@ class phinorm2psinormTestCase(unittest.TestCase):
         out_t = et.phinorm2psinorm(matrix_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # scalar psinorm, vector t:
@@ -4952,14 +4954,14 @@ class phinorm2psinormTestCase(unittest.TestCase):
         out_t = et.phinorm2psinorm(scalar_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2psinorm_scalar_psinorm_vector_t_each_t_False(self):
@@ -4974,14 +4976,14 @@ class phinorm2psinormTestCase(unittest.TestCase):
         out_t = et.phinorm2psinorm(vector_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2psinorm_vector_psinorm_vector_t_each_t_False(self):
@@ -4996,14 +4998,14 @@ class phinorm2psinormTestCase(unittest.TestCase):
         out_t = et.phinorm2psinorm(matrix_psinorm, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2psinorm_matrix_psinorm_vector_t_each_t_False(self):
@@ -5024,14 +5026,14 @@ class phinorm2psinormTestCase(unittest.TestCase):
         out_t = et.phinorm2psinorm(matrix_psinorm, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
 class phinorm2volnormTestCase(unittest.TestCase):
@@ -5046,15 +5048,15 @@ class phinorm2volnormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2volnorm_scalar_psinorm_scalar_t_each_t_False(self):
@@ -5063,15 +5065,15 @@ class phinorm2volnormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # vector psinorm, scalar t:
@@ -5080,17 +5082,17 @@ class phinorm2volnormTestCase(unittest.TestCase):
         out_t = et.phinorm2volnorm(vector_psinorm, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # res2 = (out - out_t)**2
-        # diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        # diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2volnorm_vector_psinorm_scalar_t_each_t_False(self):
@@ -5098,17 +5100,17 @@ class phinorm2volnormTestCase(unittest.TestCase):
         out_t = et.phinorm2volnorm(vector_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # res2 = (out - out_t)**2
-        # diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        # diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # matrix psinorm, scalar t:
@@ -5117,17 +5119,17 @@ class phinorm2volnormTestCase(unittest.TestCase):
         out_t = et.phinorm2volnorm(matrix_psinorm, scalar_t)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # res2 = (out - out_t)**2
-        # diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        # diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2volnorm_matrix_psinorm_scalar_t_each_t_False(self):
@@ -5135,17 +5137,17 @@ class phinorm2volnormTestCase(unittest.TestCase):
         out_t = et.phinorm2volnorm(matrix_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # res2 = (out - out_t)**2
-        # diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        # diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # scalar psinorm, vector t:
@@ -5154,14 +5156,14 @@ class phinorm2volnormTestCase(unittest.TestCase):
         out_t = et.phinorm2volnorm(scalar_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2volnorm_scalar_psinorm_vector_t_each_t_False(self):
@@ -5176,18 +5178,18 @@ class phinorm2volnormTestCase(unittest.TestCase):
         out_t = et.phinorm2volnorm(vector_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_psinorm)))
         # TODO: Fix boundary!
-        # self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        # self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2volnorm_vector_psinorm_vector_t_each_t_False(self):
@@ -5202,18 +5204,18 @@ class phinorm2volnormTestCase(unittest.TestCase):
         out_t = et.phinorm2volnorm(matrix_psinorm, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
         # TODO: Fix boundary!
-        # self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        # self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2volnorm_matrix_psinorm_vector_t_each_t_False(self):
@@ -5234,17 +5236,17 @@ class phinorm2volnormTestCase(unittest.TestCase):
         out_t = et.phinorm2volnorm(matrix_psinorm, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
 class phinorm2rmidTestCase(unittest.TestCase):
@@ -5259,15 +5261,15 @@ class phinorm2rmidTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2rmid_scalar_psinorm_scalar_t_each_t_False_rho_False(self):
@@ -5276,15 +5278,15 @@ class phinorm2rmidTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2rmid_scalar_psinorm_scalar_t_each_t_True_rho_True(self):
@@ -5293,15 +5295,15 @@ class phinorm2rmidTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2rmid_scalar_psinorm_scalar_t_each_t_False_rho_True(self):
@@ -5310,15 +5312,15 @@ class phinorm2rmidTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # vector psinorm, scalar t:
@@ -5327,17 +5329,17 @@ class phinorm2rmidTestCase(unittest.TestCase):
         out_t = et.phinorm2rmid(vector_psinorm, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2rmid_vector_psinorm_scalar_t_each_t_False_rho_False(self):
@@ -5345,17 +5347,17 @@ class phinorm2rmidTestCase(unittest.TestCase):
         out_t = et.phinorm2rmid(vector_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2rmid_vector_psinorm_scalar_t_each_t_True_rho_True(self):
@@ -5363,17 +5365,17 @@ class phinorm2rmidTestCase(unittest.TestCase):
         out_t = et.phinorm2rmid(vector_psinorm, scalar_t, rho=True)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2rmid_vector_psinorm_scalar_t_each_t_False_rho_True(self):
@@ -5381,17 +5383,17 @@ class phinorm2rmidTestCase(unittest.TestCase):
         out_t = et.phinorm2rmid(vector_psinorm, scalar_t, each_t=False, rho=True)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # matrix psinorm, scalar t:
@@ -5400,17 +5402,17 @@ class phinorm2rmidTestCase(unittest.TestCase):
         out_t = et.phinorm2rmid(matrix_psinorm, scalar_t)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2rmid_matrix_psinorm_scalar_t_each_t_False_rho_False(self):
@@ -5418,17 +5420,17 @@ class phinorm2rmidTestCase(unittest.TestCase):
         out_t = et.phinorm2rmid(matrix_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2rmid_matrix_psinorm_scalar_t_each_t_True_rho_True(self):
@@ -5436,17 +5438,17 @@ class phinorm2rmidTestCase(unittest.TestCase):
         out_t = et.phinorm2rmid(matrix_psinorm, scalar_t, rho=True)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2rmid_matrix_psinorm_scalar_t_each_t_False_rho_True(self):
@@ -5454,17 +5456,17 @@ class phinorm2rmidTestCase(unittest.TestCase):
         out_t = et.phinorm2rmid(matrix_psinorm, scalar_t, each_t=False, rho=True)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # scalar psinorm, vector t:
@@ -5473,14 +5475,14 @@ class phinorm2rmidTestCase(unittest.TestCase):
         out_t = et.phinorm2rmid(scalar_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2rmid_scalar_psinorm_vector_t_each_t_False_rho_False(self):
@@ -5494,14 +5496,14 @@ class phinorm2rmidTestCase(unittest.TestCase):
         out_t = et.phinorm2rmid(scalar_psinorm, vector_t, rho=True)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2rmid_scalar_psinorm_vector_t_each_t_False_rho_True(self):
@@ -5516,17 +5518,17 @@ class phinorm2rmidTestCase(unittest.TestCase):
         out_t = et.phinorm2rmid(vector_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # res2 = (out - out_t)**2
-        # diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        # diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2rmid_vector_psinorm_vector_t_each_t_False_rho_False(self):
@@ -5540,17 +5542,17 @@ class phinorm2rmidTestCase(unittest.TestCase):
         out_t = et.phinorm2rmid(vector_psinorm, vector_t, rho=True)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # res2 = (out - out_t)**2
-        # diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        # diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2rmid_vector_psinorm_vector_t_each_t_False_rho_True(self):
@@ -5565,17 +5567,17 @@ class phinorm2rmidTestCase(unittest.TestCase):
         out_t = et.phinorm2rmid(matrix_psinorm, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # res2 = (out - out_t)**2
-        # diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        # diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2rmid_matrix_psinorm_vector_t_each_t_False_rho_False(self):
@@ -5589,17 +5591,17 @@ class phinorm2rmidTestCase(unittest.TestCase):
         out_t = et.phinorm2rmid(matrix_psinorm, vector_t, rho=True)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # res2 = (out - out_t)**2
-        # diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        # diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2rmid_matrix_psinorm_vector_t_each_t_False_rho_True(self):
@@ -5620,17 +5622,17 @@ class phinorm2rmidTestCase(unittest.TestCase):
         out_t = et.phinorm2rmid(matrix_psinorm, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2rmid_matrix_psinorm_matrix_t_each_t_True_rho_True(self):
@@ -5644,17 +5646,17 @@ class phinorm2rmidTestCase(unittest.TestCase):
         out_t = et.phinorm2rmid(matrix_psinorm, matrix_t, each_t=False, rho=True)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
 class phinorm2roaTestCase(unittest.TestCase):
@@ -5669,15 +5671,15 @@ class phinorm2roaTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2roa_scalar_psinorm_scalar_t_each_t_False(self):
@@ -5686,15 +5688,15 @@ class phinorm2roaTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # vector psinorm, scalar t:
@@ -5703,17 +5705,17 @@ class phinorm2roaTestCase(unittest.TestCase):
         out_t = et.phinorm2roa(vector_psinorm, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2roa_vector_psinorm_scalar_t_each_t_False(self):
@@ -5721,17 +5723,17 @@ class phinorm2roaTestCase(unittest.TestCase):
         out_t = et.phinorm2roa(vector_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # matrix psinorm, scalar t:
@@ -5740,17 +5742,17 @@ class phinorm2roaTestCase(unittest.TestCase):
         out_t = et.phinorm2roa(matrix_psinorm, scalar_t)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2roa_matrix_psinorm_scalar_t_each_t_False(self):
@@ -5758,17 +5760,17 @@ class phinorm2roaTestCase(unittest.TestCase):
         out_t = et.phinorm2roa(matrix_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # scalar psinorm, vector t:
@@ -5777,14 +5779,14 @@ class phinorm2roaTestCase(unittest.TestCase):
         out_t = et.phinorm2roa(scalar_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2roa_scalar_psinorm_vector_t_each_t_False(self):
@@ -5799,17 +5801,17 @@ class phinorm2roaTestCase(unittest.TestCase):
         out_t = et.phinorm2roa(vector_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # res2 = (out - out_t)**2
-        # diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        # diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2roa_vector_psinorm_vector_t_each_t_False(self):
@@ -5824,17 +5826,17 @@ class phinorm2roaTestCase(unittest.TestCase):
         out_t = et.phinorm2roa(matrix_psinorm, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # res2 = (out - out_t)**2
-        # diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        # diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_phinorm2roa_matrix_psinorm_vector_t_each_t_False(self):
@@ -5855,17 +5857,17 @@ class phinorm2roaTestCase(unittest.TestCase):
         out_t = et.phinorm2roa(matrix_psinorm, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
 class volnorm2psinormTestCase(unittest.TestCase):
@@ -5880,15 +5882,15 @@ class volnorm2psinormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2psinorm_scalar_psinorm_scalar_t_each_t_False(self):
@@ -5897,15 +5899,15 @@ class volnorm2psinormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # vector psinorm, scalar t:
@@ -5914,14 +5916,14 @@ class volnorm2psinormTestCase(unittest.TestCase):
         out_t = et.volnorm2psinorm(vector_psinorm, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2psinorm_vector_psinorm_scalar_t_each_t_False(self):
@@ -5929,14 +5931,14 @@ class volnorm2psinormTestCase(unittest.TestCase):
         out_t = et.volnorm2psinorm(vector_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # matrix psinorm, scalar t:
@@ -5945,14 +5947,14 @@ class volnorm2psinormTestCase(unittest.TestCase):
         out_t = et.volnorm2psinorm(matrix_psinorm, scalar_t)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2psinorm_matrix_psinorm_scalar_t_each_t_False(self):
@@ -5960,14 +5962,14 @@ class volnorm2psinormTestCase(unittest.TestCase):
         out_t = et.volnorm2psinorm(matrix_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # scalar psinorm, vector t:
@@ -5976,14 +5978,14 @@ class volnorm2psinormTestCase(unittest.TestCase):
         out_t = et.volnorm2psinorm(scalar_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2psinorm_scalar_psinorm_vector_t_each_t_False(self):
@@ -5998,14 +6000,14 @@ class volnorm2psinormTestCase(unittest.TestCase):
         out_t = et.volnorm2psinorm(vector_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2psinorm_vector_psinorm_vector_t_each_t_False(self):
@@ -6020,14 +6022,14 @@ class volnorm2psinormTestCase(unittest.TestCase):
         out_t = et.volnorm2psinorm(matrix_psinorm, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2psinorm_matrix_psinorm_vector_t_each_t_False(self):
@@ -6048,14 +6050,14 @@ class volnorm2psinormTestCase(unittest.TestCase):
         out_t = et.volnorm2psinorm(matrix_psinorm, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
 class volnorm2phinormTestCase(unittest.TestCase):
@@ -6070,15 +6072,15 @@ class volnorm2phinormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2phinorm_scalar_psinorm_scalar_t_each_t_False(self):
@@ -6087,15 +6089,15 @@ class volnorm2phinormTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # vector psinorm, scalar t:
@@ -6104,17 +6106,17 @@ class volnorm2phinormTestCase(unittest.TestCase):
         out_t = et.volnorm2phinorm(vector_psinorm, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # res2 = (out - out_t)**2
-        # diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        # diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2phinorm_vector_psinorm_scalar_t_each_t_False(self):
@@ -6122,17 +6124,17 @@ class volnorm2phinormTestCase(unittest.TestCase):
         out_t = et.volnorm2phinorm(vector_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # res2 = (out - out_t)**2
-        # diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        # diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # matrix psinorm, scalar t:
@@ -6141,17 +6143,17 @@ class volnorm2phinormTestCase(unittest.TestCase):
         out_t = et.volnorm2phinorm(matrix_psinorm, scalar_t)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # res2 = (out - out_t)**2
-        # diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        # diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2phinorm_matrix_psinorm_scalar_t_each_t_False(self):
@@ -6159,17 +6161,17 @@ class volnorm2phinormTestCase(unittest.TestCase):
         out_t = et.volnorm2phinorm(matrix_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # res2 = (out - out_t)**2
-        # diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        # diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # scalar psinorm, vector t:
@@ -6178,14 +6180,14 @@ class volnorm2phinormTestCase(unittest.TestCase):
         out_t = et.volnorm2phinorm(scalar_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2phinorm_scalar_psinorm_vector_t_each_t_False(self):
@@ -6200,18 +6202,18 @@ class volnorm2phinormTestCase(unittest.TestCase):
         out_t = et.volnorm2phinorm(vector_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_psinorm)))
         # TODO: Fix boundary!
-        # self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        # self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2phinorm_vector_psinorm_vector_t_each_t_False(self):
@@ -6226,18 +6228,18 @@ class volnorm2phinormTestCase(unittest.TestCase):
         out_t = et.volnorm2phinorm(matrix_psinorm, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
         # TODO: Fix boundary!
-        # self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        # self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        # self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        # self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2phinorm_matrix_psinorm_vector_t_each_t_False(self):
@@ -6258,17 +6260,17 @@ class volnorm2phinormTestCase(unittest.TestCase):
         out_t = et.volnorm2phinorm(matrix_psinorm, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # res2 = (out - out_t)**2
-        # diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        # diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
 class volnorm2rmidTestCase(unittest.TestCase):
@@ -6283,15 +6285,15 @@ class volnorm2rmidTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2rmid_scalar_psinorm_scalar_t_each_t_False_rho_False(self):
@@ -6300,15 +6302,15 @@ class volnorm2rmidTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2rmid_scalar_psinorm_scalar_t_each_t_True_rho_True(self):
@@ -6317,15 +6319,15 @@ class volnorm2rmidTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2rmid_scalar_psinorm_scalar_t_each_t_False_rho_True(self):
@@ -6334,15 +6336,15 @@ class volnorm2rmidTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # vector psinorm, scalar t:
@@ -6351,17 +6353,17 @@ class volnorm2rmidTestCase(unittest.TestCase):
         out_t = et.volnorm2rmid(vector_psinorm, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2rmid_vector_psinorm_scalar_t_each_t_False_rho_False(self):
@@ -6369,17 +6371,17 @@ class volnorm2rmidTestCase(unittest.TestCase):
         out_t = et.volnorm2rmid(vector_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2rmid_vector_psinorm_scalar_t_each_t_True_rho_True(self):
@@ -6387,17 +6389,17 @@ class volnorm2rmidTestCase(unittest.TestCase):
         out_t = et.volnorm2rmid(vector_psinorm, scalar_t, rho=True)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2rmid_vector_psinorm_scalar_t_each_t_False_rho_True(self):
@@ -6405,17 +6407,17 @@ class volnorm2rmidTestCase(unittest.TestCase):
         out_t = et.volnorm2rmid(vector_psinorm, scalar_t, each_t=False, rho=True)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # matrix psinorm, scalar t:
@@ -6424,17 +6426,17 @@ class volnorm2rmidTestCase(unittest.TestCase):
         out_t = et.volnorm2rmid(matrix_psinorm, scalar_t)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2rmid_matrix_psinorm_scalar_t_each_t_False_rho_False(self):
@@ -6442,17 +6444,17 @@ class volnorm2rmidTestCase(unittest.TestCase):
         out_t = et.volnorm2rmid(matrix_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2rmid_matrix_psinorm_scalar_t_each_t_True_rho_True(self):
@@ -6460,17 +6462,17 @@ class volnorm2rmidTestCase(unittest.TestCase):
         out_t = et.volnorm2rmid(matrix_psinorm, scalar_t, rho=True)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2rmid_matrix_psinorm_scalar_t_each_t_False_rho_True(self):
@@ -6478,17 +6480,17 @@ class volnorm2rmidTestCase(unittest.TestCase):
         out_t = et.volnorm2rmid(matrix_psinorm, scalar_t, each_t=False, rho=True)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # scalar psinorm, vector t:
@@ -6497,14 +6499,14 @@ class volnorm2rmidTestCase(unittest.TestCase):
         out_t = et.volnorm2rmid(scalar_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2rmid_scalar_psinorm_vector_t_each_t_False_rho_False(self):
@@ -6518,14 +6520,14 @@ class volnorm2rmidTestCase(unittest.TestCase):
         out_t = et.volnorm2rmid(scalar_psinorm, vector_t, rho=True)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2rmid_scalar_psinorm_vector_t_each_t_False_rho_True(self):
@@ -6540,17 +6542,17 @@ class volnorm2rmidTestCase(unittest.TestCase):
         out_t = et.volnorm2rmid(vector_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # res2 = (out - out_t)**2
-        # diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        # diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2rmid_vector_psinorm_vector_t_each_t_False_rho_False(self):
@@ -6564,17 +6566,17 @@ class volnorm2rmidTestCase(unittest.TestCase):
         out_t = et.volnorm2rmid(vector_psinorm, vector_t, rho=True)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # res2 = (out - out_t)**2
-        # diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        # diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2rmid_vector_psinorm_vector_t_each_t_False_rho_True(self):
@@ -6589,17 +6591,17 @@ class volnorm2rmidTestCase(unittest.TestCase):
         out_t = et.volnorm2rmid(matrix_psinorm, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # res2 = (out - out_t)**2
-        # diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        # diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2rmid_matrix_psinorm_vector_t_each_t_False_rho_False(self):
@@ -6613,17 +6615,17 @@ class volnorm2rmidTestCase(unittest.TestCase):
         out_t = et.volnorm2rmid(matrix_psinorm, vector_t, rho=True)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # res2 = (out - out_t)**2
-        # diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        # diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2rmid_matrix_psinorm_vector_t_each_t_False_rho_True(self):
@@ -6644,17 +6646,17 @@ class volnorm2rmidTestCase(unittest.TestCase):
         out_t = et.volnorm2rmid(matrix_psinorm, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2rmid_matrix_psinorm_matrix_t_each_t_True_rho_True(self):
@@ -6668,17 +6670,17 @@ class volnorm2rmidTestCase(unittest.TestCase):
         out_t = et.volnorm2rmid(matrix_psinorm, matrix_t, each_t=False, rho=True)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
 class volnorm2roaTestCase(unittest.TestCase):
@@ -6693,15 +6695,15 @@ class volnorm2roaTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2roa_scalar_psinorm_scalar_t_each_t_False(self):
@@ -6710,15 +6712,15 @@ class volnorm2roaTestCase(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             iter(out)
-        self.assertFalse(scipy.isnan(out))
-        self.assertFalse(scipy.isinf(out))
+        self.assertFalse(numpy.isnan(out))
+        self.assertFalse(numpy.isinf(out))
 
         with self.assertRaises(TypeError):
             iter(out_t)
-        self.assertFalse(scipy.isnan(out_t))
-        self.assertFalse(scipy.isinf(out_t))
+        self.assertFalse(numpy.isnan(out_t))
+        self.assertFalse(numpy.isinf(out_t))
 
-        diff = scipy.absolute(out - out_t) / scipy.absolute(out).max()
+        diff = numpy.absolute(out - out_t) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     # vector psinorm, scalar t:
@@ -6727,17 +6729,17 @@ class volnorm2roaTestCase(unittest.TestCase):
         out_t = et.volnorm2roa(vector_psinorm, scalar_t)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2roa_vector_psinorm_scalar_t_each_t_False(self):
@@ -6745,17 +6747,17 @@ class volnorm2roaTestCase(unittest.TestCase):
         out_t = et.volnorm2roa(vector_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_psinorm),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # matrix psinorm, scalar t:
@@ -6764,17 +6766,17 @@ class volnorm2roaTestCase(unittest.TestCase):
         out_t = et.volnorm2roa(matrix_psinorm, scalar_t)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2roa_matrix_psinorm_scalar_t_each_t_False(self):
@@ -6782,17 +6784,17 @@ class volnorm2roaTestCase(unittest.TestCase):
         out_t = et.volnorm2roa(matrix_psinorm, scalar_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     # scalar psinorm, vector t:
@@ -6801,14 +6803,14 @@ class volnorm2roaTestCase(unittest.TestCase):
         out_t = et.volnorm2roa(scalar_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t),))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2roa_scalar_psinorm_vector_t_each_t_False(self):
@@ -6823,17 +6825,17 @@ class volnorm2roaTestCase(unittest.TestCase):
         out_t = et.volnorm2roa(vector_psinorm, vector_t)
 
         self.assertEqual(out.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, (len(vector_t), len(vector_psinorm)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         # res2 = (out - out_t)**2
-        # diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        # diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2roa_vector_psinorm_vector_t_each_t_False(self):
@@ -6848,17 +6850,17 @@ class volnorm2roaTestCase(unittest.TestCase):
         out_t = et.volnorm2roa(matrix_psinorm, vector_t)
 
         self.assertEqual(out.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, tuple([len(vector_t),] + list(matrix_psinorm.shape)))
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
     def test_volnorm2roa_matrix_psinorm_vector_t_each_t_False(self):
@@ -6879,17 +6881,17 @@ class volnorm2roaTestCase(unittest.TestCase):
         out_t = et.volnorm2roa(matrix_psinorm, matrix_t, each_t=False)
 
         self.assertEqual(out.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out).any())
-        self.assertFalse(scipy.isinf(out).any())
+        self.assertFalse(numpy.isnan(out).any())
+        self.assertFalse(numpy.isinf(out).any())
 
         self.assertEqual(out_t.shape, matrix_psinorm.shape)
-        self.assertFalse(scipy.isnan(out_t).any())
-        self.assertFalse(scipy.isinf(out_t).any())
+        self.assertFalse(numpy.isnan(out_t).any())
+        self.assertFalse(numpy.isinf(out_t).any())
 
-        # diff = scipy.sqrt(((out - out_t)**2).max()) / scipy.absolute(out).max()
-        self.assertTrue((scipy.isnan(out) == scipy.isnan(out_t)).all())
+        # diff = numpy.sqrt(((out - out_t)**2).max()) / numpy.absolute(out).max()
+        self.assertTrue((numpy.isnan(out) == numpy.isnan(out_t)).all())
         res2 = (out - out_t)**2
-        diff = scipy.sqrt((res2[~scipy.isnan(res2)]).max()) / scipy.absolute(out[~scipy.isnan(out)]).max()
+        diff = numpy.sqrt((res2[~numpy.isnan(res2)]).max()) / numpy.absolute(out[~numpy.isnan(out)]).max()
         self.assertLessEqual(diff, tol)
 
 class SqrtTestCase(unittest.TestCase):
@@ -7494,89 +7496,89 @@ class SelfConsistencyTestCase(unittest.TestCase):
     """Test the internal self-consistency of the basic conversions.
     """
     def test_rz2psi(self):
-        R, Z = scipy.meshgrid(e.getRGrid(), e.getZGrid())
+        R, Z = numpy.meshgrid(e.getRGrid(), e.getZGrid())
         out = e.rz2psi(R, Z, e.getTimeBase())
         out_t = et.rz2psi(R, Z, e.getTimeBase())
 
         # Psi gets its sign reversed, so I use plus here.
-        diff = scipy.sqrt(((out + e.getFluxGrid())**2).max()) / scipy.absolute(e.getFluxGrid()).max()
+        diff = numpy.sqrt(((out + e.getFluxGrid())**2).max()) / numpy.absolute(e.getFluxGrid()).max()
         self.assertLessEqual(diff, tol)
 
-        diff = scipy.sqrt(((out_t + et.getFluxGrid())**2).max()) / scipy.absolute(et.getFluxGrid()).max()
+        diff = numpy.sqrt(((out_t + et.getFluxGrid())**2).max()) / numpy.absolute(et.getFluxGrid()).max()
         self.assertLessEqual(diff, tol)
 
     def test_rz2psinorm(self):
-        R, Z = scipy.meshgrid(e.getRGrid(), e.getZGrid())
+        R, Z = numpy.meshgrid(e.getRGrid(), e.getZGrid())
         out = e.rz2psinorm(R, Z, e.getTimeBase())
         out_t = et.rz2psinorm(R, Z, e.getTimeBase())
 
         psinorm_grid = (
-            (-1 * e.getFluxGrid() - e.getFluxAxis()[:, scipy.newaxis, scipy.newaxis]) /
-            (e.getFluxLCFS()[:, scipy.newaxis, scipy.newaxis] - e.getFluxAxis()[:, scipy.newaxis, scipy.newaxis])
+            (-1 * e.getFluxGrid() - e.getFluxAxis()[:, numpy.newaxis, numpy.newaxis]) /
+            (e.getFluxLCFS()[:, numpy.newaxis, numpy.newaxis] - e.getFluxAxis()[:, numpy.newaxis, numpy.newaxis])
         )
         psinorm_grid_t = (
-            (-1 * et.getFluxGrid() - et.getFluxAxis()[:, scipy.newaxis, scipy.newaxis]) /
-            (et.getFluxLCFS()[:, scipy.newaxis, scipy.newaxis] - et.getFluxAxis()[:, scipy.newaxis, scipy.newaxis])
+            (-1 * et.getFluxGrid() - et.getFluxAxis()[:, numpy.newaxis, numpy.newaxis]) /
+            (et.getFluxLCFS()[:, numpy.newaxis, numpy.newaxis] - et.getFluxAxis()[:, numpy.newaxis, numpy.newaxis])
         )
 
-        diff = scipy.sqrt(((out - psinorm_grid)**2).max()) / scipy.absolute(psinorm_grid).max()
+        diff = numpy.sqrt(((out - psinorm_grid)**2).max()) / numpy.absolute(psinorm_grid).max()
         self.assertLessEqual(diff, tol)
 
-        diff = scipy.sqrt(((out_t - psinorm_grid_t)**2).max()) / scipy.absolute(psinorm_grid_t).max()
+        diff = numpy.sqrt(((out_t - psinorm_grid_t)**2).max()) / numpy.absolute(psinorm_grid_t).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2volnorm(self):
-        psinorm_grid = scipy.linspace(0, 1, e.getFluxVol().shape[1])
-        psinorm_grid_t = scipy.linspace(0, 1, et.getFluxVol().shape[1])
+        psinorm_grid = numpy.linspace(0, 1, e.getFluxVol().shape[1])
+        psinorm_grid_t = numpy.linspace(0, 1, et.getFluxVol().shape[1])
 
-        volnorm_grid = e.getFluxVol() / e.getFluxVol()[:, -1, scipy.newaxis]
-        volnorm_grid_t = et.getFluxVol() / et.getFluxVol()[:, -1, scipy.newaxis]
+        volnorm_grid = e.getFluxVol() / e.getFluxVol()[:, -1, numpy.newaxis]
+        volnorm_grid_t = et.getFluxVol() / et.getFluxVol()[:, -1, numpy.newaxis]
 
         out = e.psinorm2volnorm(psinorm_grid, e.getTimeBase())
         out_t = et.psinorm2volnorm(psinorm_grid, et.getTimeBase())
 
-        diff = scipy.sqrt(((out - volnorm_grid)**2).max()) / scipy.absolute(volnorm_grid).max()
+        diff = numpy.sqrt(((out - volnorm_grid)**2).max()) / numpy.absolute(volnorm_grid).max()
         self.assertLessEqual(diff, tol)
 
-        diff = scipy.sqrt(((out_t - volnorm_grid_t)**2).max()) / scipy.absolute(volnorm_grid_t).max()
+        diff = numpy.sqrt(((out_t - volnorm_grid_t)**2).max()) / numpy.absolute(volnorm_grid_t).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2rmid(self):
-        psinorm_grid = scipy.linspace(0, 1, e.getRmidPsi().shape[1])
-        psinorm_grid_t = scipy.linspace(0, 1, et.getRmidPsi().shape[1])
+        psinorm_grid = numpy.linspace(0, 1, e.getRmidPsi().shape[1])
+        psinorm_grid_t = numpy.linspace(0, 1, et.getRmidPsi().shape[1])
 
         out = e.psinorm2rmid(psinorm_grid, e.getTimeBase())
         out_t = et.psinorm2rmid(psinorm_grid, et.getTimeBase())
 
-        diff = scipy.sqrt(((out - e.getRmidPsi())**2).max()) / scipy.absolute(e.getRmidPsi()).max()
+        diff = numpy.sqrt(((out - e.getRmidPsi())**2).max()) / numpy.absolute(e.getRmidPsi()).max()
         self.assertLessEqual(diff, tol)
 
         self.assertLessEqual(diff, tol)
 
-        diff = scipy.sqrt(((out_t - et.getRmidPsi())**2).max()) / scipy.absolute(et.getRmidPsi()).max()
+        diff = numpy.sqrt(((out_t - et.getRmidPsi())**2).max()) / numpy.absolute(et.getRmidPsi()).max()
         self.assertLessEqual(diff, tol)
 
     def test_roa2rmid(self):
-        roa_grid = scipy.linspace(0, 1, len(e.getRGrid()))
+        roa_grid = numpy.linspace(0, 1, len(e.getRGrid()))
         out = e.roa2rmid(roa_grid, e.getTimeBase())
 
         rmid_grid = (
-            roa_grid[scipy.newaxis, :] * (e.getRmidOut()[:, scipy.newaxis] -
-            e.getMagR()[:, scipy.newaxis]) + e.getMagR()[:, scipy.newaxis]
+            roa_grid[numpy.newaxis, :] * (e.getRmidOut()[:, numpy.newaxis] -
+            e.getMagR()[:, numpy.newaxis]) + e.getMagR()[:, numpy.newaxis]
         )
 
-        diff = scipy.sqrt(((out - rmid_grid)**2).max()) / scipy.absolute(rmid_grid).max()
+        diff = numpy.sqrt(((out - rmid_grid)**2).max()) / numpy.absolute(rmid_grid).max()
         self.assertLessEqual(diff, tol)
 
-        roa_grid_t = scipy.linspace(0, 1, len(et.getRGrid()))
+        roa_grid_t = numpy.linspace(0, 1, len(et.getRGrid()))
         out_t = et.roa2rmid(roa_grid_t, et.getTimeBase())
 
         rmid_grid_t = (
-            roa_grid_t[scipy.newaxis, :] * (et.getRmidOut()[:, scipy.newaxis] -
-            et.getMagR()[:, scipy.newaxis]) + et.getMagR()[:, scipy.newaxis]
+            roa_grid_t[numpy.newaxis, :] * (et.getRmidOut()[:, numpy.newaxis] -
+            et.getMagR()[:, numpy.newaxis]) + et.getMagR()[:, numpy.newaxis]
         )
 
-        diff = scipy.sqrt(((out_t - rmid_grid_t)**2).max()) / scipy.absolute(rmid_grid_t).max()
+        diff = numpy.sqrt(((out_t - rmid_grid_t)**2).max()) / numpy.absolute(rmid_grid_t).max()
         self.assertLessEqual(diff, tol)
 
     def test_psinorm2phinorm(self):


### PR DESCRIPTION
This does the following

- Adds a CI check using Arm-ubuntu, x86-ubuntu, and x86-windows. Note, trispline fails certain unittests, so it is currently forced to pass. Mathematical verification of certain conversions needs to be done with trispline based equilibrium interpolations
- Changes in testing were necessary in order to import the python2 pickle file
- Convert all basic use of scipy to numpy as to follow changes which occurred in scipy
- alias cumulative_trapezoidal function of scipy to old name cumtrapz to allow for wide (python 2, older scipy, etc) as well as new version support
- Remove use of f2py as numpy.distutils is deprecated. Develop a native binding using standard numpy C-API and python C-API. This should provide longer term support by the various components with reduced maintenance.
- Codify dependence on setuptools
- Verify pyproject.toml functionality


Note to anyone who finds this: maintenance by the original maintainers is minimal. Follow-up updates are unlikely to occur.